### PR TITLE
fix urls when baseURL is not at root

### DIFF
--- a/layouts/partials/docs/html-head.html
+++ b/layouts/partials/docs/html-head.html
@@ -3,7 +3,7 @@
 <title>{{- template "title" . }} | {{ .Site.Title -}}</title>
 
 <link href="https://fonts.googleapis.com/css?family=Oxygen|Oxygen+Mono:300,400,700" rel="stylesheet">
-<link rel="stylesheet" href="/normalize.min.css">
+<link rel="stylesheet" href="{{ "/normalize.min.css" | relURL }}">
 
 {{ $styles := resources.Get "book.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $styles.RelPermalink }}">

--- a/layouts/partials/docs/mobile-header.html
+++ b/layouts/partials/docs/mobile-header.html
@@ -1,4 +1,4 @@
 <label for="menu-control">
-  <img src="{{- .Site.BaseURL -}}/svg/menu.svg" />
+  <img src="{{ "svg/menu.svg" | absURL }}" />
 </label>
 <strong>{{- template "title" . }}</strong>


### PR DESCRIPTION
When base URL = `https://xxx/ggg`, `/normalize.min.css` would result in error 404.