### PR TITLE
add smooth scrolling for table-of-content navigation by default

### DIFF
--- a/assets/book.scss
+++ b/assets/book.scss
@@ -5,6 +5,7 @@
 html {
   font-size: $font-size-base;
   letter-spacing: 0.33px;
+  scroll-behavior: smooth;
 }
 
 html,


### PR DESCRIPTION
Smooth scrolling between anchors on a page is, in my opinion, a nice default for documentation sites.  Love the theme!