### PR TITLE
Add custom_css param into a header

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -5,9 +5,6 @@
 <head>
   {{ partial "docs/html-head" . }}
   {{ partial "docs/inject/head" . }}
-  {{ range .Site.Params.custom_css -}}
-    <link rel="stylesheet" href="{{ . | absURL }}">
-  {{- end }}
 </head>
 {{ $content := `
 # Hugo Book Theme

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -5,6 +5,9 @@
 <head>
   {{ partial "docs/html-head" . }}
   {{ partial "docs/inject/head" . }}
+  {{ range .Site.Params.custom_css -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+  {{- end }}
 </head>
 {{ $content := `
 # Hugo Book Theme

--- a/layouts/partials/docs/inject/head.html
+++ b/layouts/partials/docs/inject/head.html
@@ -1,0 +1,3 @@
+{{ range .Site.Params.custom_css -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+{{- end }}


### PR DESCRIPTION
Enable custom CSS support via custom_css param in the params section. The idea was tentatively stolen from  https://discourse.gohugo.io/t/how-to-override-css-classes-with-hugo/3033/4