### PR TITLE
Fix bug: remove dots in blog post pagination ul

### DIFF
--- a/assets/book.scss
+++ b/assets/book.scss
@@ -79,6 +79,7 @@ aside nav ul {
 ul.pagination {
   display: flex;
   justify-content: center;
+  list-style-type: none;
 
   .page-item a {
     padding: $padding-16;


### PR DESCRIPTION
There's a display issue with pagination on blog post list pages:

![image](https://user-images.githubusercontent.com/3482051/61440093-08612d00-a943-11e9-9e21-fbb16eea2843.png)

I'm not super confident in my CSS knowledge so I don't know if this is the "correct" fix, but these are coming from the standard `list-style-type: disc`. Adding  `list-style-type: none` to `ul.pagination` in https://github.com/alex-shpak/hugo-book/blob/master/assets/book.scss#L79 fixed it for me.