### PR TITLE
make markdown tables scroll

### DIFF
--- a/assets/_markdown.scss
+++ b/assets/_markdown.scss
@@ -62,6 +62,8 @@
   }
 
   table {
+    overflow: auto;
+    display: block;
     border-spacing: 0;
     border-collapse: collapse;
     margin-top: $padding-16;


### PR DESCRIPTION
hi @alex-shpak 

I noticed that wide markdown tables don't scroll so I'm contributing this change. You can compare [before](https://deploy-preview-10--condescending-wing-a192db.netlify.com/) and [after](https://deploy-preview-12--condescending-wing-a192db.netlify.com/) by shrinking your browser down.

 I'm no CSS expert, let me know if I should have down anything differently. thanks