### PR TITLE
Optional brand logo in the menu controlled by .Site.Params.BookLogo

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ disableKinds = ['taxonomy', 'taxonomyTerm']
 # You can also specify this parameter per page in front matter
 BookToC = 3
 
+# (Optional, default none) Set the path to a logo for the book. If the logo is
+# /static/logo.png then the path would be /logo.png
+BookLogo = '/logo.png'
+
 # (Optional, default none) Set leaf bundle to render as side menu
 # When not specified file structure and weights will be used
 BookMenuBundle = '/menu'

--- a/assets/book.scss
+++ b/assets/book.scss
@@ -98,9 +98,7 @@ ul.pagination {
     max-width: 40px;
     max-height: 40px;
     vertical-align: middle;
-  }
-  span {
-    margin-left: 0.5rem;
+    margin-right: 0.5rem;
   }
 }
 

--- a/assets/book.scss
+++ b/assets/book.scss
@@ -93,6 +93,15 @@ ul.pagination {
 
 .book-brand {
   margin-top: 0;
+
+  img {
+    max-width: 40px;
+    max-height: 40px;
+    vertical-align: middle;
+  }
+  span {
+    margin-left: 0.5rem;
+  }
 }
 
 .book-menu {

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,6 +20,10 @@ pygmentsCodeFences = true
   # You can also specify this parameter per page in front matter
   BookToC = 3
 
+  # (Optional, default none) Set the path to a logo for the book. If the logo is
+  # /static/logo.png then the path would be /logo.png
+  # BookLogo = '/logo.png'
+
   # (Optional, default none) Set leaf bundle to render as side menu
   # When not specified file structure and weights will be used
   BookMenuBundle = '/menu'

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -20,6 +20,10 @@ params:
   # You can also specify this parameter per page in front matter
   BookToC: 3
 
+  # (Optional, default none) Set the path to a logo for the book. If the logo is
+  # /static/logo.png then the path would be /logo.png
+  # BookLogo: /logo.png
+
   # (Optional, default none) Set leaf bundle to render as side menu
   # When not specified file structure and weights will be used
   BookMenuBundle: /menu
@@ -45,6 +49,6 @@ params:
   # - In blog posts
   BookDateFormat: 'Jan 2, 2006'
 
-  # (Optional, default true) Enables search function with lunr.js, 
+  # (Optional, default true) Enables search function with lunr.js,
   # Index is built on fly, therefore it might slowdown your website.
   BookSearch: true

--- a/layouts/partials/docs/brand.html
+++ b/layouts/partials/docs/brand.html
@@ -1,12 +1,8 @@
 <h2 class="book-brand">
-  <a href="{{ .Site.BaseURL }}">
+  <a href="{{ .Site.BaseURL }}"><span>
     {{- with .Site.Params.BookLogo -}}
       <img src="{{ . | relURL }}" alt="Logo" />
-      <span>
     {{- end -}}
     {{ .Site.Title }}
-    {{- with .Site.Params.BookLogo -}}
-      </span>
-    {{- end -}}
-  </a>
+  </span></a>
 </h2>

--- a/layouts/partials/docs/brand.html
+++ b/layouts/partials/docs/brand.html
@@ -1,7 +1,7 @@
 <h2 class="book-brand">
   <a href="{{ .Site.BaseURL }}">
     {{- with .Site.Params.BookLogo -}}
-      <img src="{{ . }}" alt="Logo" />
+      <img src="{{ . | relURL }}" alt="Logo" />
       <span>
     {{- end -}}
     {{ .Site.Title }}

--- a/layouts/partials/docs/brand.html
+++ b/layouts/partials/docs/brand.html
@@ -1,3 +1,12 @@
 <h2 class="book-brand">
-  <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+  <a href="{{ .Site.BaseURL }}">
+    {{- with .Site.Params.BookLogo -}}
+      <img src="{{ . }}" alt="Logo" />
+      <span>
+    {{- end -}}
+    {{ .Site.Title }}
+    {{- with .Site.Params.BookLogo -}}
+      </span>
+    {{- end -}}
+  </a>
 </h2>


### PR DESCRIPTION
Without a logo things look the same. With a logo the menu now has a bit of flair:

<img width="244" alt="with-logo" src="https://user-images.githubusercontent.com/1276382/64080441-09f37400-cca9-11e9-9bd7-cbb8e4909a48.png">

I've added documentation for how to use the logo in the README and the example configurations. I didn't feel comfortable picking a default logo for all sites, so did not add one.