### PR TITLE
replacing any backslashes with forward slashes

### DIFF
--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -17,7 +17,7 @@
 
   {{ if and .File .Site.Params.BookRepo .Site.Params.BookEditPath }}
   <div>
-    <a class="flex align-center" href="{{ .Site.Params.BookRepo }}/{{ .Site.Params.BookEditPath }}/{{ .File.Path }}" target="_blank">
+    <a class="flex align-center" href="{{ .Site.Params.BookRepo }}/{{ .Site.Params.BookEditPath }}/{{ replace .File.Path "\\" "/" }}" target="_blank">
       <img src="{{ "svg/edit.svg" | relURL }}" class="book-icon" alt="Edit" />
       <span>{{ i18n "Edit this page" }}</span>
     </a>


### PR DESCRIPTION
Seems to be a Windows related thing. `.File.Path` returns a path with backslashes this adds a replace to make those forward slashes. This appears to fix #115