### PR TITLE
feat: added the 'Subtitle' parameter, useful for showing the author

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ enableGitInfo = true
 disableKinds = ['taxonomy', 'taxonomyTerm']
   
 [params]
+
+  # (Optional, default is empty) a subtitle to show below the main book title.
+  Subtitle = "By Author Name"
+  
   # (Optional, default 6) Set how many table of contents levels to be showed on page.
   # Use false to hide ToC, note that 0 will default to 6 (https://gohugo.io/functions/default/)
   # You can also specify this parameter per page in front matter

--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -109,6 +109,10 @@ ul.pagination {
   }
 }
 
+.book-subtitle {
+  font-size: $font-size-14;
+}
+
 .book-menu {
   flex: 0 0 $menu-width;
   font-size: $font-size-14;

--- a/layouts/partials/docs/brand.html
+++ b/layouts/partials/docs/brand.html
@@ -6,3 +6,9 @@
     <span>{{ .Site.Title }}</span>
   </a>
 </h2>
+{{ if .Site.Params.Subtitle }}
+<h2 class="book-subtitle">
+  <span>{{ .Site.Params.Subtitle }}</span>
+</h2>
+{{ end }}
+


### PR DESCRIPTION
This pull request adds an optional `Subtitle` parameter to the `params`. This is useful if the theme user wants to show the author name or any kind of extra information below the title.

This is a non-breaking change - by default the field is not set, and the theme renders just like the original version.

Here is a screenshot of how it looks:

![image](https://user-images.githubusercontent.com/1926984/71777353-cac29000-2fc6-11ea-9f49-55f2ed90bbfa.png)

Apologies if I've gotten anything wrong on the Hugo config / HTML / SCSS side, I'm fairly new to the codebase!

Thanks so much for the excellent theme and documentation, it made it very straightforward to make a minor modification like this.
