### PR TITLE
feat: added support for Disqus

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - Customisable
 - Zero initial configuration
 - Handy shortcodes
+- Optional support for Disqus
 
 ## Requirements
 
@@ -116,6 +117,10 @@ You can also see `yaml` example [here](https://github.com/alex-shpak/hugo-book/b
 # (Optional) Set Google Analytics if you use it to track your website.
 # Always put it on the top of the configuration file, otherwise it won't work
 googleAnalytics = "UA-XXXXXXXXX-X"
+
+# (Optional) If you provide a Disqus shortname, comments will be enabled on
+# pages.
+# disqusShortname = "my-site"
 
 # (Optional) Set this to true if you use capital letters in file names
 disablePathToLower = true

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ You can also see `yaml` example [here](https://github.com/alex-shpak/hugo-book/b
 googleAnalytics = "UA-XXXXXXXXX-X"
 
 # (Optional) If you provide a Disqus shortname, comments will be enabled on
-# pages.
-# disqusShortname = "my-site"
+# all pages.
+disqusShortname = "my-site"
 
 # (Optional) Set this to true if you use capital letters in file names
 disablePathToLower = true
@@ -195,6 +195,9 @@ bookHidden = true
 
 # (Optional) Set how many levels of ToC to show. use 'false' to hide ToC completely
 bookToC = 3
+
+# If you have enabled Disqus for the site, you can disable it for specific pages.
+bookDisableComments = true
 ```
 
 ### Partials

--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -235,6 +235,12 @@ ul.pagination {
   }
 }
 
+// Give a little extra space before showing Disqus comments. See:
+// https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/disqus.html#L3
+#disqus_thread {
+  padding-top: $padding-16;
+}
+
 .book-languages {
   position: relative;
   overflow: visible;

--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -26,6 +26,6 @@
 
 </div>
 
-{{ if .Site.DisqusShortname }}
+{{ if and (not (eq .Site.DisqusShortname "")) (not .Params.bookDisableComments ) }}
   {{ template "_internal/disqus.html" . }}
 {{ end }}

--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -25,3 +25,7 @@
   {{ end }}
 
 </div>
+
+{{ if .Site.DisqusShortname }}
+  {{ template "_internal/disqus.html" . }}
+{{ end }}


### PR DESCRIPTION
This PR adds support for Disqus. If the standard Hugo `disqusShortname` configuration is provided, comments will be enabled for pages. This is a non-breaking change, comments are disabled by default.

![image](https://user-images.githubusercontent.com/1926984/71778185-9d7bdf00-2fd2-11ea-921b-2188ff0796d7.png)

Apologies if I've got something wrong here, am fairly new to Hugo!

Disqus can be disabled for any content by setting the following in the frontmatter:

```
disable_comments: true
```

See [effectiive-shell](https://effective-shell.com) for an example. Disqus is disabled on the main index page, and enabled for each chapter.