### PR TITLE
mobile toc menu

### DIFF
--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -295,7 +295,7 @@ aside nav,
   will-change: transform, margin;
 }
 
-@media screen and (max-width: $sm-breakpoint) {
+@media screen and (max-width: $md-breakpoint) {
   .book-menu {
     margin-left: -$menu-width;
     font-size: $font-size-base;

--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -322,7 +322,7 @@ aside nav,
       transform: rotate(90deg);
     }
   }
-  #toc-menu-control:checked ~ main {
+  #toc-control:checked ~ main {
     aside #TableOfContents,
     .book-page {
       transform: translateX(-$menu-width);

--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -291,14 +291,8 @@ aside nav,
 .book-page,
 .markdown {
   transition: 0.2s ease-in-out;
-  transition-property: transform, margin-left, opacity;
-  will-change: transform, margin-left;
-}
-
-@media screen and (max-width: $md-breakpoint) {
-  .book-toc {
-    display: none;
-  }
+  transition-property: transform, margin, opacity;
+  will-change: transform, margin;
 }
 
 @media screen and (max-width: $sm-breakpoint) {
@@ -306,21 +300,35 @@ aside nav,
     margin-left: -$menu-width;
     font-size: $font-size-base;
   }
+  .book-toc {
+    margin-right: -$toc-width;
+    font-size: $font-size-base;
+  }
 
   .book-header {
     display: flex;
   }
 
-  #menu-control:checked + main {
-    .book-menu nav,
+  
+  #menu-control:checked ~ main {
+    .book-menu #BookMenu,
     .book-page {
       transform: translateX($menu-width);
     }
-
-    .book-header label {
+    .markdown {
+      opacity: 0.25;
+    }
+    .book-header #menu-control {
       transform: rotate(90deg);
     }
-
+  }
+  //html body main.flex.container aside.book-menu.fixed nav
+  //html body main.flex.container aside.book-toc.levels-3.fixed nav#TableOfContents
+  #toc-menu-control:checked ~ main {
+    aside #TableOfContents,
+    .book-page {
+      transform: translateX(-$menu-width);
+    }
     .markdown {
       opacity: 0.25;
     }

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,6 +7,7 @@
 </head>
 
 <body>
+  <input type="checkbox" class="hidden" id="toc-menu-control" />
   <input type="checkbox" class="hidden" id="menu-control" />
   <main class="flex container">
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
 </head>
 
 <body>
-  <input type="checkbox" class="hidden" id="toc-menu-control" />
+  <input type="checkbox" class="hidden" id="toc-control" />
   <input type="checkbox" class="hidden" id="menu-control" />
   <main class="flex container">
 

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -1,4 +1,4 @@
-<nav>
+<nav id="BookMenu">
 {{ partial "docs/brand" . }}
 {{ partial "docs/search" . }}
 {{ partial "docs/inject/menu-before" . }}

--- a/layouts/partials/docs/mobile-header.html
+++ b/layouts/partials/docs/mobile-header.html
@@ -1,6 +1,8 @@
 <header class="flex align-center justify-between book-header">
-  <label for="menu-control">
+  <label id="menu-control" for="menu-control">
     <img src="{{ "svg/menu.svg" | relURL }}" class="book-icon" alt="Menu" />
   </label>
+  <label id="tos-menu-control" for="toc-menu-control">
   <strong>{{ partial "docs/title" . }}</strong>
+  </label>
 </header>

--- a/layouts/partials/docs/mobile-header.html
+++ b/layouts/partials/docs/mobile-header.html
@@ -2,7 +2,7 @@
   <label id="menu-control" for="menu-control">
     <img src="{{ "svg/menu.svg" | relURL }}" class="book-icon" alt="Menu" />
   </label>
-  <label id="tos-menu-control" for="toc-menu-control">
+  <label id="toc-control" for="toc-control">
   <strong>{{ partial "docs/title" . }}</strong>
   </label>
 </header>

--- a/layouts/partials/docs/toc.html
+++ b/layouts/partials/docs/toc.html
@@ -2,7 +2,7 @@
 {{ if and $tocLevels .Page.TableOfContents }}
   <aside class="book-toc levels-{{$tocLevels}} fixed">
     {{ with .Page.TableOfContents }}
-    <label id="tos-menu-control" for="toc-menu-control">
+    <label id="toc-control" for="toc-control">
     {{ . }}
     </label>
     {{ end }}

--- a/layouts/partials/docs/toc.html
+++ b/layouts/partials/docs/toc.html
@@ -1,6 +1,10 @@
 {{ $tocLevels := default (default 6 .Site.Params.BookToC) .Params.BookToC }}
 {{ if and $tocLevels .Page.TableOfContents }}
   <aside class="book-toc levels-{{$tocLevels}} fixed">
-    {{ .Page.TableOfContents }}
+    {{ with .Page.TableOfContents }}
+    <label id="tos-menu-control" for="toc-menu-control">
+    {{ . }}
+    </label>
+    {{ end }}
   </aside>
 {{ end }}


### PR DESCRIPTION
This allows the TOC to be visible from smaller devices in the same manner as the menu.

* Uses Page title as label
* Label entries so that tapping TOC will hide menu