### PR TITLE
Removing flex from <main> for sake of print layout

### DIFF
--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -320,7 +320,6 @@ aside nav,
     display: flex;
   }
 
-
   #menu-control:checked ~ main {
     .book-menu #BookMenu,
     .book-page {

--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -47,6 +47,11 @@ img {
   vertical-align: baseline;
 }
 
+main {
+  display: flex;
+  flex-direction: row-reverse;
+}
+
 aside nav ul {
   padding: 0;
   margin: 0;
@@ -315,7 +320,7 @@ aside nav,
     display: flex;
   }
 
-  
+
   #menu-control:checked ~ main {
     .book-menu #BookMenu,
     .book-page {

--- a/assets/_print.scss
+++ b/assets/_print.scss
@@ -5,7 +5,7 @@
   }
 
   main {
-    flex-direction: column-reverse;
+    display: block;
   }
 
   .book-toc {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,11 +9,8 @@
 <body>
   <input type="checkbox" class="hidden" id="toc-control" />
   <input type="checkbox" class="hidden" id="menu-control" />
-  <main class="flex container">
-
-    <aside class="book-menu fixed">
-      {{ partial "docs/menu" . }}
-    </aside>
+  <main class="container">
+    {{ template "toc" . }}
 
     <div class="book-page">
       {{ partial "docs/mobile-header" . }}
@@ -22,7 +19,9 @@
       {{ partial "docs/inject/footer" . }}
     </div>
 
-    {{ template "toc" . }}
+    <aside class="book-menu fixed">
+      {{ partial "docs/menu" . }}
+    </aside>
   </main>
 
   {{ partial "docs/inject/body" . }}


### PR DESCRIPTION
I haven't thoroughly experimented with this, but it seems to solve the problem I raised in #127. 

1. Removes `flex` class from `<main>`, adds the flex layout back in `_main.css`.
2. Alters the ordering of the child elements of main in the `baseof.html` template, so they run opposite of their current layout. (I imagine this point is most likely to cause problems, but in my brief testing I didn't notice any.)
3. `flex-direction` on `main` set to row-reverse, so it visually matches the current look. 
4. In `_print.css`, the `.book-menu` column is already hidden with `display: none`, so being in the different order doesn't matter. 
5. Changing `main`'s style in `_print.css` from `flex-direction: column-reverse;` to `display: block;` takes out the problematic `flex`, and with the new ordering in the HTML, the table of contents appears properly on top without needing to reverse it with flex. 

Happy to make any further changes if needed. 