### PR TITLE
Disable Default Highlight

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -16,6 +16,9 @@ enableGitInfo = true
 [markup.tableOfContents]
   startLevel = 1
 
+[markup.highlight]
+  codeFences = false
+
 # Multi-lingual mode config
 # There are different options to translate files
 # See https://gohugo.io/content-management/multilingual/#translation-by-filename

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -15,6 +15,8 @@ markup:
       unsafe: true
   tableOfContents:
     startLevel: 1
+  highlight:
+    codeFences: true
 
 # Multi-lingual mode config
 # There are different options to translate files


### PR DESCRIPTION
Add parameters
1. config.toml
```
[markup.highlight]
  codeFences = false
```
and
2. config.yaml
```
highlight:
    codeFences: true
```
to deactivate default highlight, so we can modify the highlight theme.
If we use ```assets/_custom.scss```, we will only see changes to the ```/content/posts/```, but not to ```/content/docs/```