### PR TITLE
GitHub Workflow: always use latest version of Hugo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,9 @@ jobs:
 
       - name: Install Hugo
         run: |
-          wget https://github.com/gohugoio/hugo/releases/download/v0.60.1/hugo_extended_0.60.1_Linux-64bit.deb -O /tmp/hugo.deb
+          LATEST_VERSION=`curl --silent "https://api.github.com/repos/gohugoio/hugo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'`
+          VERSION_NO_PREFIX=`echo $LATEST_VERSION | cut -c 2-`
+          wget "https://github.com/gohugoio/hugo/releases/download/$LATEST_VERSION/hugo_extended_${VERSION_NO_PREFIX}_Linux-64bit.deb" -O /tmp/hugo.deb
           sudo dpkg -i /tmp/hugo.deb
 
       - name: Run Hugo


### PR DESCRIPTION
Fetch the latest tag (release) from GitHub API as variable, `LATEST_VERSION` (e.g. `v0.65.3`).
The `VERSION_NO_PREFIX` is a substring of `LATEST_VERSION` but with the first initial `v` removed (e.g. `0.65.3`).
Download the corresponding ".deb" package using the variables.
Tested locally.

Also, I just wanted to say thank you for making this theme, I use it on [utb.vilhelmprytz.se](https://utb.vilhelmprytz.se) which is a site for Swedish educational material :smile: 