### PR TITLE
GitHub workflow: check with minimum supported version of Hugo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Build with Hugo
 on: [push]
 
 jobs:
-  hugo:
+  hugo-latest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -13,6 +13,19 @@ jobs:
           LATEST_VERSION=`curl --silent "https://api.github.com/repos/gohugoio/hugo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'`
           VERSION_NO_PREFIX=`echo $LATEST_VERSION | cut -c 2-`
           wget "https://github.com/gohugoio/hugo/releases/download/$LATEST_VERSION/hugo_extended_${VERSION_NO_PREFIX}_Linux-64bit.deb" -O /tmp/hugo.deb
+          sudo dpkg -i /tmp/hugo.deb
+
+      - name: Run Hugo
+        working-directory: exampleSite
+        run: hugo --themesDir ../..
+  hugo-minimum:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install Hugo
+        run: |
+          wget "https://github.com/gohugoio/hugo/releases/download/v0.60.0/hugo_extended_0.60.0_Linux-64bit.deb" -O /tmp/hugo.deb
           sudo dpkg -i /tmp/hugo.deb
 
       - name: Run Hugo


### PR DESCRIPTION
Added build job that checks with the minimum supported version of Hugo

**Note**: I have not tested this, I don't really know how to test the workflow locally. Is there any way you can try it out before merging with master (perhaps merging with another branch)?

(as discussed in #159)