### PR TITLE
Make 'Edit this page' content directory language independent

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -73,8 +73,8 @@ enableGitInfo = true
 
   # Enable "Edit this page" links for 'doc' page type.
   # Disabled by default. Uncomment to enable. Requires 'BookRepo' param.
-  # Path must point to 'content' directory of repo.
-  BookEditPath = 'edit/master/exampleSite/content'
+  # Edit path must point to root directory of repo.
+  BookEditPath = 'edit/master/exampleSite'
 
   # Configure the date format used on the pages
   # - In git information

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -69,8 +69,8 @@ params:
 
   # Enable "Edit this page" links for 'doc' page type.
   # Disabled by default. Uncomment to enable. Requires 'BookRepo' param.
-  # Path must point to 'content' directory of repo.
-  BookEditPath: edit/master/exampleSite/content
+  # Edit path must point to root directory of repo.
+  BookEditPath: edit/master/exampleSite
 
   # Configure the date format used on the pages
   # - In git information

--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -15,7 +15,7 @@
 
 {{ if and .File .Site.Params.BookRepo .Site.Params.BookEditPath }}
   <div>
-    <a class="flex align-center" href="{{ .Site.Params.BookRepo }}/{{ .Site.Params.BookEditPath }}/{{ replace .File.Path "\\" "/" }}" target="_blank" rel="noopener">
+    <a class="flex align-center" href="{{ .Site.Params.BookRepo }}/{{ .Site.Params.BookEditPath }}/{{ .Site.Params.contentDir }}/{{ replace .File.Path "\\" "/" }}" target="_blank" rel="noopener">
       <img src="{{ "svg/edit.svg" | relURL }}" class="book-icon" alt="Edit" />
       <span>{{ i18n "Edit this page" }}</span>
     </a>


### PR DESCRIPTION
Addresses #200

``` yaml
languages:                                                                      
  en:                                                                           
    languageName: English                                                       
    contentDir: content/en                                                      
    weight: 1                                                                   
  ru:                                                                           
    languageName: Russian                                                       
    contentDir: content.ru                                                      
    weight: 2
```
It looks like `.Site.Params.contentDir` will show the specific `contentDir` when the language is changed creating links such as
```
https://github.com/user/exampleSite/edit/master/content/en/docs/file.md
https://github.com/user/exampleSite/edit/master/content.ru/docs/file.md
```
___
It is a breaking change, with
``` toml
  BookEditPath = 'edit/master/exampleSite/content'
```
changing to 
``` toml
BookEditPath = 'edit/master/exampleSite'
```