### PR TITLE
Hide ToC icon in header if ToC not enabled

### DIFF
--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -6,6 +6,8 @@
   <strong>{{ partial "docs/title" . }}</strong>
 
   <label for="toc-control">
+    {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}
     <img src="{{ "svg/toc.svg" | relURL }}" class="book-icon" alt="Table of Contents" />
+    {{ end }}
   </label>
 </div>


### PR DESCRIPTION
The ToC icon was shown on smaller displays even if there was no ToC. It was confusing.
I decided to render the "label" tag but not the "img" tag so that the "justify-between" css-class still works and no changes to the stylesheet are necessary.