### PR TITLE
allow customizing how search results are rendered

### DIFF
--- a/assets/search.js
+++ b/assets/search.js
@@ -64,13 +64,17 @@
 
     const searchHits = window.bookSearchIndex.search(input.value, 10);
     searchHits.forEach(function(page) {
-      const li = document.createElement('li'),
-            a = li.appendChild(document.createElement('a'));
+      if(window.renderSearchResults) {
+        window.renderSearchResults(page, results);
+      } else {
+          const li = document.createElement('li'),
+          a = li.appendChild(document.createElement('a'));
 
-      a.href = page.href;
-      a.textContent = page.title;
+          a.href = page.href;
+          a.textContent = page.title;
 
-      results.appendChild(li);
+          results.appendChild(li);
+      }
     });
   }
 


### PR DESCRIPTION
Checks if `window.renderSearchResults(page, results)` is defined if it's defined it calls that function, otherwise renders as default.

This gives flexibility to be able to change & extend rendering of search. One can easily define this function anywhere instead of overriding `search.js` to change how to render stuff.

#### Background

I use it to have breadcrumb menu under search results (just by parsing `href`). As you see otherwise it's not so fun when content grows & more and more pages have same names.

![image](https://user-images.githubusercontent.com/15555035/83926874-68470900-a78b-11ea-8c1d-414e5e4dcb91.png)
