### PR TITLE
mathjax v3 support

### DIFF
--- a/layouts/partials/docs/inject/head.html
+++ b/layouts/partials/docs/inject/head.html
@@ -1,0 +1,1 @@
+{{ partial "mathjax_support.html" . }}

--- a/layouts/partials/mathjax_support.html
+++ b/layouts/partials/mathjax_support.html
@@ -1,0 +1,22 @@
+<script>
+  MathJax = {
+    tex: {
+      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      displayMath: [['$$','$$'], ['\\[', '\\]']],
+      processEscapes: true,
+      processEnvironments: true
+    },
+    options: {
+      skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+    }
+  };
+
+  window.addEventListener('load', (event) => {
+      document.querySelectorAll("mjx-container").forEach(function(x){
+        x.parentElement.classList += 'has-jax'})
+    });
+
+</script>
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script type="text/javascript" id="MathJax-script" async
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>


### PR DESCRIPTION
I am using ox-hugo to generate the hugo markdown from org-mode files.
ox-hugo support math expressions that work with mathjax.

The syntax is also signficantly simpler than `{{katex}}` ...

Based on https://geoffruddock.com/math-typesetting-in-hugo/ I simply added mathjax support to the theme.
I am new to hugo so I am not sure if that is the right place to add or if this should be configurable.