### PR TITLE
Fix the current language permalink

### DIFF
--- a/layouts/partials/docs/languages.html
+++ b/layouts/partials/docs/languages.html
@@ -1,4 +1,3 @@
-{{ $currentpage := .Permalink }}
 <!-- Merge home and current page translations -->
 {{ $translations := dict }}
 {{ range .Site.Home.AllTranslations }}
@@ -19,7 +18,7 @@
   <ul class="book-languages-list">
     {{ range .Site.Languages }}{{ with index $translations .Lang }}
     <li class="{{ if (eq $.Site.Language .Language) }}active{{ end }}">
-      <a href="{{ if (eq $.Site.Language .Language) }}{{ $currentpage }}{{ else }}{{ .Permalink }}{{ end }}" class="flex align-center">
+      <a href="{{ if (eq $.Site.Language .Language) }}{{ $.Permalink }}{{ else }}{{ .Permalink }}{{ end }}" class="flex align-center">
         <img src="{{ "svg/translate.svg" | relURL }}" class="book-icon" alt="Languages" />
         {{ .Language.LanguageName }}
       </a>

--- a/layouts/partials/docs/languages.html
+++ b/layouts/partials/docs/languages.html
@@ -1,3 +1,4 @@
+{{ $currentpage := .Permalink }}
 <!-- Merge home and current page translations -->
 {{ $translations := dict }}
 {{ range .Site.Home.AllTranslations }}
@@ -18,7 +19,7 @@
   <ul class="book-languages-list">
     {{ range .Site.Languages }}{{ with index $translations .Lang }}
     <li class="{{ if (eq $.Site.Language .Language) }}active{{ end }}">
-      <a href="{{ .Permalink }}" class="flex align-center">
+      <a href="{{ if (eq $.Site.Language .Language) }}{{ $currentpage }}{{ else }}{{ .Permalink }}{{ end }}" class="flex align-center">
         <img src="{{ "svg/translate.svg" | relURL }}" class="book-icon" alt="Languages" />
         {{ .Language.LanguageName }}
       </a>


### PR DESCRIPTION
The current page is linked to the root page instead itself.

![1610009901364](https://user-images.githubusercontent.com/5027939/103873813-678ba200-50e1-11eb-8000-6580d9ea4287.png)

## Note

_As I can see It's not the best solution because the `$translations` collection is filled with redundant links. I don't understand how to exclude them. For example are links to non-existent translations. All this should not interfere with the PR because we are not changing the process of iterating over the `$translations` dict._