### PR TITLE
Bug Fix: Empty .Site.Params.contentDir

### DIFF
--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -15,7 +15,7 @@
 
 {{ if and .File .Site.Params.BookRepo .Site.Params.BookEditPath }}
   <div>
-    <a class="flex align-center" href="{{ .Site.Params.BookRepo }}/{{ .Site.Params.BookEditPath }}/{{ or .Site.Params.contentDir "content" }}/{{ replace .File.Path "\\" "/" }}" target="_blank" rel="noopener">
+    <a class="flex align-center" href="{{ .Site.Params.BookRepo }}/{{ .Site.Params.BookEditPath }}/{{ .Site.Params.contentDir | default "content" }}/{{ replace .File.Path "\\" "/" }}" target="_blank" rel="noopener">
       <img src="{{ "svg/edit.svg" | relURL }}" class="book-icon" alt="Edit" />
       <span>{{ i18n "Edit this page" }}</span>
     </a>

--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -15,7 +15,7 @@
 
 {{ if and .File .Site.Params.BookRepo .Site.Params.BookEditPath }}
   <div>
-    <a class="flex align-center" href="{{ .Site.Params.BookRepo }}/{{ .Site.Params.BookEditPath }}/{{ .Site.Params.contentDir }}/{{ replace .File.Path "\\" "/" }}" target="_blank" rel="noopener">
+    <a class="flex align-center" href="{{ .Site.Params.BookRepo }}/{{ .Site.Params.BookEditPath }}/{{ or .Site.Params.contentDir "content" }}/{{ replace .File.Path "\\" "/" }}" target="_blank" rel="noopener">
       <img src="{{ "svg/edit.svg" | relURL }}" class="book-icon" alt="Edit" />
       <span>{{ i18n "Edit this page" }}</span>
     </a>


### PR DESCRIPTION
When .Site.Params.contentDir is left as the default: "content", calling .Site.Params.contentDir returns nothing, or maybe an empty string. To fix this, we set a default value for .Site.Params.contentDir to "content" and the url is built correctly.