### PR TITLE
Add documentation for mermaid init config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ There are few empty partials you can override in `layouts/partials/`
 | `assets/_custom.scss`    | Customise or override scss styles                                                     |
 | `assets/_variables.scss` | Override default SCSS variables                                                       |
 | `assets/_fonts.scss`     | Replace default font with custom fonts (e.g. local files or remote like google fonts) |
-| `assets/mermaid.json`    | Replace mermaid initialization config                                                 |
+| `assets/mermaid.json`    | Replace Mermaid initialization config                                                 |
 
 ### Plugins
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ There are few empty partials you can override in `layouts/partials/`
 | `assets/_custom.scss`    | Customise or override scss styles                                                     |
 | `assets/_variables.scss` | Override default SCSS variables                                                       |
 | `assets/_fonts.scss`     | Replace default font with custom fonts (e.g. local files or remote like google fonts) |
+| `assets/mermaid.json`    | Replace mermaid initialization config                                                 |
 
 ### Plugins
 

--- a/exampleSite/content/docs/shortcodes/mermaid.md
+++ b/exampleSite/content/docs/shortcodes/mermaid.md
@@ -2,6 +2,13 @@
 
 [Mermaid](https://mermaidjs.github.io/) is library for generating svg charts and diagrams from text.
 
+{{< hint info >}}
+**Override Mermaid Initialization Config**
+
+To override the [initialization config](https://mermaid-js.github.io/mermaid/#/Setup) for Mermaid,
+create a `mermaid.json` file in your `assets` folder!
+{{< /hint >}}
+
 ## Example
 
 {{< columns >}}
@@ -36,3 +43,4 @@ sequenceDiagram
 {{< /mermaid >}}
 
 {{< /columns >}}
+


### PR DESCRIPTION
Make it more obvious how to override the initialization configuration for Mermaid using `assets/mermaid.json`.