### PR TITLE
Fixed ineffective "disableHugoGeneratorInject" parameter

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,12 +1,9 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Language.LanguageDirection | default "ltr" }}">
-
 <head>
-  {{ hugo.Generator }}
   {{ partial "docs/html-head" . }}
   {{ partial "docs/inject/head" . }}
 </head>
-
 <body dir="{{ .Site.Language.LanguageDirection | default "ltr" }}">
   <input type="checkbox" class="hidden toggle" id="menu-control" />
   <input type="checkbox" class="hidden toggle" id="toc-control" />
@@ -47,7 +44,6 @@
 
   {{ partial "docs/inject/body" . }}
 </body>
-
 </html>
 
 {{ define "menu" }}


### PR DESCRIPTION
Fixed issue #336. HUGO does not use `{{ hugo.Generator }}` placeholder anymore.