### PR TITLE
(GH-375) Enable use as a hugo module

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,29 @@ Then run hugo (or set `theme = "book"`/`theme: book` in configuration file)
 hugo server --minify --theme book
 ```
 
+### Via Module
+
+You can also add this theme as a Hugo module instead of a git submodule.
+Navigate to your hugo project root and edit your `config.toml`:
+
+```toml
+[module]
+[[module.imports]]
+path = 'github.com/alex-shpak/hugo-book'
+```
+
+Then, to load/update the theme module, run:
+
+```sh
+hugo mod get -u
+```
+
+Finally, run hugo:
+
+```sh
+hugo server --minify
+```
+
 ### Creating site from scratch
 
 Below is an example on how to create a new site from scratch:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/alex-shpak/hugo-book
+
+go 1.16


### PR DESCRIPTION
This commit does the minimal work to make the Book theme a functional
hugo module by adding the go.mod file and including instructions in
the project README for use.

Resolves #375