### PR TITLE
Removed extra Google Analitics include

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -29,7 +29,6 @@
     </main>
 
     {{ partial "docs/inject/body" . }}
-    {{ template "_internal/google_analytics_async.html" . }}
   </body>
 
   </html>


### PR DESCRIPTION
It's already included via "docs/html-head" partial.

Signed-off-by: raspopov raspopov@cherubicsoft.com
