### PR TITLE
prevent breaked-lines in <p>

### DIFF
--- a/assets/_markdown.scss
+++ b/assets/_markdown.scss
@@ -87,6 +87,10 @@
     }
   }
 
+  p {
+    word-wrap:break-word;
+  }
+
   blockquote {
     margin: $padding-16 0;
     padding: $padding-8 $padding-16 $padding-8 ($padding-16 - $padding-4); //to keep total left space 16dp


### PR DESCRIPTION
When containing some extremely long lines, like attached below, hugo-book will let it overflow by default.
<img width="1077" alt="Snipaste_2021-12-30_11-49-40" src="https://user-images.githubusercontent.com/53211446/147720271-b5ffe1bd-0593-4289-87f9-c1081c284263.png">

This PR is intended to change this behaviour to `break-words`, like attached below.
![image](https://user-images.githubusercontent.com/53211446/147720339-91d68325-4c08-4c12-ac6a-63296ad12828.png)
