### PR TITLE
Make menu entries' link relative

### DIFF
--- a/layouts/partials/docs/menu-filetree.html
+++ b/layouts/partials/docs/menu-filetree.html
@@ -31,12 +31,12 @@
   {{ if .Page.Params.bookCollapseSection }}
     <input type="checkbox" id="section-{{ md5 .Page }}" class="toggle" {{ if or $current $ancestor }}checked{{ end }} />
     <label for="section-{{ md5 .Page }}" class="flex justify-between">
-      <a {{ if .Page.Content }}href="{{ .Page.Permalink }}"{{ else }}role="button"{{ end }} class="{{ if $current }}active{{ end }}">
+      <a {{ if .Page.Content }}href="{{ .Page.RelPermalink }}"{{ else }}role="button"{{ end }} class="{{ if $current }}active{{ end }}">
         {{- partial "docs/title" .Page -}}
       </a>
     </label>
   {{ else if .Page.Content }}
-    <a href="{{ .Page.Permalink }}" class="{{ if $current }} active{{ end }}">
+    <a href="{{ .Page.RelPermalink }}" class="{{ if $current }} active{{ end }}">
       {{- partial "docs/title" .Page -}}
     </a>
   {{ else }}


### PR DESCRIPTION
This change allows hugo to build pages correcly when
`canonifyURLs = false` and `relativeURLs = true`.
Otherwise the links on the menu will be canonicalized regardless of
configuration.
This results in broken sites in a number of situations, such as sites
served behind a reverse-proxy that don't want to account for the prefix
they're served under.