### PR TITLE
Translate the "Categories" and "Tags" taxonomy titles

### DIFF
--- a/layouts/partials/docs/taxonomy.html
+++ b/layouts/partials/docs/taxonomy.html
@@ -3,7 +3,7 @@
   {{ range $term, $_ := .Site.Taxonomies }}
     {{ with $.Site.GetPage (printf "/%s" $term | urlize) }}
     <li class="book-section-flat">
-      <strong>{{ .Title | title }}</strong>
+      <strong>{{ i18n (lower .Title) | default .Title | title }}</strong>
       <ul>
       {{ range .Pages }}
         <li class="flex justify-between">


### PR DESCRIPTION
Probably it's also need to add to "i18n/en.toml" file the next lines:
```
[categories]
other = "Categories"

[tags]
other = "Tags"
```

Signed-off-by: raspopov <raspopov@cherubicsoft.com>