### PR TITLE
Improved menu title display when title is too long

### DIFF
--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -158,6 +158,13 @@ body[dir="rtl"] .book-menu {
   > ul {
     padding-inline-start: 0;
   }
+  
+  ul li > a[href] {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    overflow: hidden;
+  }
 }
 
 .book-page {

--- a/layouts/partials/docs/menu-filetree.html
+++ b/layouts/partials/docs/menu-filetree.html
@@ -36,7 +36,7 @@
       </a>
     </label>
   {{ else if .Page.Content }}
-    <a href="{{ .Page.RelPermalink }}" class="{{ if $current }} active{{ end }}">
+    <a href="{{ .Page.RelPermalink }}" class="{{ if $current }} active{{ end }}" title='{{- partial "docs/title" .Page -}}'>
       {{- partial "docs/title" .Page -}}
     </a>
   {{ else }}


### PR DESCRIPTION
It might be a good idea to hide a headline when it's too long. If you agree~

before：
![](https://imgtp.apqiang.com/2022/04/01/D1XXUDiz.png)

after:
![](https://imgtp.apqiang.com/2022/04/01/zWfKzqT6.png)