### PR TITLE
OnlyBookLogo — parameter to display logo only

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ disableKinds = ['taxonomy', 'taxonomyTerm']
   # /static/logo.png then the path would be 'logo.png'
   BookLogo = 'logo.png'
 
+  # (Optional, default none) Set the path to a logo for the book, to be displayed solely,
+  # without trailing text. Otherwise behaves identically to `BookLogo`.
+  OnlyBookLogo = 'logo.png'
+
   # (Optional, default none) Set leaf bundle to render as side menu
   # When not specified file structure and weights will be used
   BookMenuBundle = '/menu'

--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -88,10 +88,15 @@ ul.pagination {
   margin-top: 0;
   margin-bottom: $padding-16;
 
-  img {
+  img.base {
     height: 1.5em;
     width: 1.5em;
     margin-inline-end: $padding-8;
+  }
+  img.only {
+    margin-left: auto;
+    margin-right: auto;
+    width: 98%;
   }
 }
 

--- a/layouts/partials/docs/brand.html
+++ b/layouts/partials/docs/brand.html
@@ -1,8 +1,12 @@
 <h2 class="book-brand">
   <a class="flex align-center" href="{{ cond (not .Site.Home.File) .Sites.First.Home.RelPermalink .Site.Home.RelPermalink }}">
-    {{- with .Site.Params.BookLogo -}}
-    <img src="{{ . | relURL }}" alt="Logo" />
+    {{- if .Site.Params.BookLogo -}}
+      <img src="{{ .Site.Params.BookLogo | relURL }}" alt="Logo" class="base" />
+    {{- else if .Site.Params.OnlyBookLogo -}}
+      <img src="{{ .Site.Params.OnlyBookLogo | relURL }}" alt="Logo" class="only" />
     {{- end -}}
-    <span>{{ .Site.Title }}</span>
+    {{- if not .Site.Params.OnlyBookLogo -}}
+      <span>{{ .Site.Title }}</span>
+    {{- end -}}
   </a>
 </h2>


### PR DESCRIPTION
Addresses https://github.com/alex-shpak/hugo-book/issues/436

A couple of websites seem to be using image-only banners, probably makes sense to support this, though maybe the logic could be made even simpler, i.e. by behaving like `OnlyBookLogo` when `BookLogo` is specified but no title is given. Kept it like this because maybe the code would want to use the website `title` elsewhere as well.