### PR TITLE
Ignore code block clicks with active selection

### DIFF
--- a/assets/clipboard.js
+++ b/assets/clipboard.js
@@ -11,6 +11,9 @@
 
   document.querySelectorAll("pre code").forEach(code => {
     code.addEventListener("click", function (event) {
+      if (window.getSelection().toString()) {
+        return;
+      }
       select(code.parentElement);
 
       if (navigator.clipboard) {


### PR DESCRIPTION
The previous solution for #281 forces copying entire code block content to clipboard while trying to select the part of it, which makes partial copying impossible.

This PR prevents copy-on-click inside code blocks if there is already an active selection.

New behavior:
- single-click – select and copy entire code block to clipboard
- click-and-drag – allow user to select part of the code