### PR TITLE
Add a parameter `BookFaviconExt` to be able to change favicon extention

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ disableKinds = ['taxonomy', 'taxonomyTerm']
   # Can be overwritten by same param in page frontmatter
   BookComments = true
 
+  # (Optional, default png) Configure the favicon extension.
+  # By default favicon.png is used. If you want to use other extention(e.g. webp),
+  # set value you like.
+  BookFaviconExt = 'png'
+
   # /!\ This is an experimental feature, might be removed or changed at any time
   # (Optional, experimental, default false) Enables portable links and link checks in markdown pages.
   # Portable links meant to work with text editors and let you write markdown without {{< relref >}} shortcode

--- a/layouts/partials/docs/html-head.html
+++ b/layouts/partials/docs/html-head.html
@@ -14,7 +14,11 @@
 
 {{- $manifest := resources.Get "manifest.json" | resources.ExecuteAsTemplate "manifest.json" . }}
 <link rel="manifest" href="{{ $manifest.RelPermalink }}">
-<link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/x-icon">
+{{- if default false .Site.Params.BookFaviconExt -}}
+  <link rel="icon" href="{{ printf `favicon.%s` .Site.Params.BookFaviconExt | relURL }}" type="image/x-icon">
+{{- else -}}
+  <link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/x-icon">
+{{- end -}}
 
 {{- range .Translations }}
   <link rel="alternate" hreflang="{{ default .Language.Lang .Site.LanguageCode }}" href="{{ .Permalink }}" title="{{ partial "docs/title" . }}">


### PR DESCRIPTION
Hi 😄 
Thank you for great template!

BTW, my website uses `webp` as favicon file, and I want to use it on other site using hugo-book too.
But hugo-book supports only `favicon.png` (right?)
I understand I can use `webp` if changing template directly.
This PR is a little contribution for thanking.
I hope you like.

Thanks.