### PR TITLE
cover parent ul style

### DIFF
--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -69,6 +69,7 @@ ul.pagination {
   display: flex;
   justify-content: center;
   list-style-type: none;
+  padding-inline-start: 0px;
 
   .page-item a {
     padding: $padding-16;


### PR DESCRIPTION
As the tag `ul` style is setted blow at `_main.scss:64`:

```css
ul {
  padding-inline-start: $padding-16;
}
```

So, to keep the pagination at the center of the page, the `ul.pagination` should not inherit that style.