### PR TITLE
Open local hugo menu entries in same window

### DIFF
--- a/layouts/partials/docs/menu-hugo.html
+++ b/layouts/partials/docs/menu-hugo.html
@@ -10,7 +10,7 @@
 <ul>
   {{ range . }}
   <li>
-    <a href="{{ .URL }}" {{ if not .Page }}target="_blank" rel="noopener"{{ end }}>
+    <a href="{{ .URL }}" {{ if and (not .Page) (not (hasPrefix .URL "/")) -}} target="_blank" rel="noopener"{{ end }} >
       {{- .Pre -}}
       {{ with .Page }}
         {{ partial "docs/title" .Page }}


### PR DESCRIPTION
Prior to this change, menu entries defined in the hugo site configuration always have `target="_blank" rel="noopener"` appended to their link definition.

With this change, any entry defined in the hugo site configuration that has a url beginning with `/` -- that is, a link to a page or section in that site -- will not have those attributes included. This allows those pages to be opened/behave like the other links in the menu from the book section.