### PR TITLE
(MAINT) Respect LinkTitle in page metadata

### DIFF
--- a/layouts/partials/docs/title.html
+++ b/layouts/partials/docs/title.html
@@ -4,7 +4,9 @@
 -->
 {{ $title := "" }}
 
-{{ if .Title }}
+{{ if .LinkTitle }}
+  {{ $title = .LinkTitle }}
+{{ else if .Title }}
   {{ $title = .Title }}
 {{ else if and .IsSection .File }}
   {{ $title = path.Base .File.Dir | humanize | title }}


### PR DESCRIPTION
Prior to this commit, the partial for determining a page title used the `Title` property of a page, if present, or humanized and titleized the file name if not.

It did not use the `LinkTitle` property at all (defined in the [front matter][01]). According to the [menu documentation][02]:

> The following order is used to determine an Identifier:
>
> `.Name > .LinkTitle > .Title`
>
> This means that `.Title` will be used unless `.LinkTitle is present, etc.

Similar, the documentation for [menu entry variables][03] states:

> The `name` key, if set for the menu entry, sets this value. If that key is not set, and if the menu entry is set in a page front-matter, this value defaults to the page's `.LinkTitle`.

Together, these imply that if `.LinkTitle` is specified, it should be preferred over `.Title` for the generated nav menu.

[01]: https://gohugo.io/content-management/front-matter/
[02]: https://gohugo.io/content-management/menus/#nesting
[03]: https://gohugo.io/variables/menus/#menu-entry-variables