### PR TITLE
fix(search): searchDataURL must not use relative URL

### DIFF
--- a/assets/search.js
+++ b/assets/search.js
@@ -5,7 +5,7 @@
 {{ $searchConfig := i18n "bookSearchConfig" | default "{}" }}
 
 (function () {
-  const searchDataURL = '{{ $searchData.RelPermalink }}';
+  const searchDataURL = '{{ $searchData.Permalink }}';
   const indexConfig = Object.assign({{ $searchConfig }}, {
     doc: {
       id: 'id',


### PR DESCRIPTION
This basically allows the `flexsearch` to work when you have a suffix at your Hugo hosting, like: `https://<user>.pages.domain.com/<repository>`

It always will load the data using the `$searchData.Permalink` instead using the `$searchData.RelPermalink`.

Fixes #363