### PR TITLE
Themes dir correction and peaceiris deploy to GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,10 @@ jobs:
           - 'latest'
           - '0.79.0'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
@@ -22,3 +25,10 @@ jobs:
       - name: Run Hugo
         working-directory: exampleSite
         run: hugo --themesDir ../..
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,9 @@ jobs:
         working-directory: exampleSite
         run: hugo --themesDir ../..
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+      # - name: Deploy
+      #   uses: peaceiris/actions-gh-pages@v3
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: ./public
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-# hugo server --minify --themesDir ... --baseURL=http://0.0.0.0:1313/theme/hugo-book/
+# hugo server --minify --themesDir ../.. --baseURL=http://0.0.0.0:1313/theme/hugo-book/
 
 baseURL = 'https://example.com/'
 title = 'Hugo Book'

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -1,4 +1,4 @@
-# hugo server --minify --themesDir ... --baseURL=http://0.0.0.0:1313/theme/hugo-book/
+# hugo server --minify --themesDir ../.. --baseURL=http://0.0.0.0:1313/theme/hugo-book/
 
 baseURL: https://example.com/
 title: Hugo Book


### PR DESCRIPTION
Hi Alex, just two changes:
* the first editing the first line comment instruction on how to build in config.toml and config.yaml from `themesDir ...` to `..\..` which corrects the error stopping it from running (https://github.com/alex-shpak/hugo-book/issues/503).
* updating the actions/checkout@v2 to actions/checkout@v3, adding standard fetch of themes, and the standard use of peaceiris required(?) to deploy to GitHub Pages.

Let me know what you think. Thanks