### PR TITLE
use absolute links in search

### DIFF
--- a/assets/search.js
+++ b/assets/search.js
@@ -5,7 +5,7 @@
 {{ $searchConfig := i18n "bookSearchConfig" | default "{}" }}
 
 (function () {
-  const searchDataURL = '{{ $searchData.RelPermalink }}';
+  const searchDataURL = '{{ $searchData.Permalink }}';
   const indexConfig = Object.assign({{ $searchConfig }}, {
     doc: {
       id: 'id',


### PR DESCRIPTION
Search does not work with relative links especially with sites hosted on github pages. See below for the error that comes up:

```
en.search.min.055c318184e4b7ad6cf865f71b7d6018df91f79cc7e3f22ddbbfa1f4a569edcc.js:1
GET https://millionhz.github.io/en.search-data.min.c56fcb797f226c35f8eecb274196bad0567674214c537c14473e0972340fcd54.json 404
```

The error is reproduceable by accessing [my docs](https://millionhz.github.io/network-security-notes/) and using the search feature. 