### PR TITLE
Update meta theme-color in html-head.html

### DIFF
--- a/layouts/partials/docs/html-head.html
+++ b/layouts/partials/docs/html-head.html
@@ -1,7 +1,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="{{ default .Summary .Description }}">
-<meta name="theme-color" content="#FFFFFF">
+<meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">
+<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#343a40">
 <meta name="color-scheme" content="light dark">
 
 {{- with .Page.Params.BookHref -}}


### PR DESCRIPTION
https://github.com/alex-shpak/hugo-book/pull/468 was closed, but as suggested here https://github.com/alex-shpak/hugo-book/pull/468#issuecomment-1202471587, I think it works well.

- In the config: `BookTheme = 'auto'`
- iOS 16.3 Safari with Dark appearance
- No giscus

Before

<img src="https://user-images.githubusercontent.com/124151829/224021085-d11875ef-ac98-4df4-a7cd-1f375b172866.jpeg" width="50%">

After

<img src="https://user-images.githubusercontent.com/124151829/224021140-eb90d84a-0dbf-4324-a6bd-1d99e246fc14.jpeg" width="50%">