### PR TITLE
Update es.yaml to add missing translation

### DIFF
--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -8,7 +8,7 @@
   translation: Última modificación por
 
 - id: Expand
-  translation: Expand
+  translation: Expandir
 
 - id: bookSearchConfig
   translation: '{ cache: true }'


### PR DESCRIPTION
Added translation for 'Expand'.
Should be 'Expandir' instead.