### PR TITLE
fix server worker is blocked

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,14 +1,14 @@
 {
   "name": "{{ .Site.Title }}",
   "short_name": "{{ .Site.Title }}",
-  "start_url": "{{ "/" | relURL }}",
-  "scope": "{{ "/" | relURL }}",
+  "start_url": "{{ "./" | relURL }}",
+  "scope": "{{ "./" | relURL }}",
   "display": "standalone",
   "background_color": "#000000",
   "theme_color": "#000000",
   "icons": [
     {
-      "src": "{{ "/favicon.svg" | relURL }}",
+      "src": "{{ "./favicon.svg" | relURL }}",
       "sizes": "512x512"
     }
   ]

--- a/assets/sw-register.js
+++ b/assets/sw-register.js
@@ -2,6 +2,6 @@
 if (navigator.serviceWorker) {
   navigator.serviceWorker.register(
     "{{ $swJS.RelPermalink }}", 
-    { scope: "{{ "/" | relURL }}" }
+    { scope: "{{ "./" | relURL }}" }
   );
 }


### PR DESCRIPTION
When baseURL is not the root directory：
Uncaught (in promise) DOMException: Failed to register a ServiceWorker for scope ('https://lizongying.github.io/') with script ('https://lizongying.github.io/go-crawler/docs/sw.js'): The path of the provided scope ('/') is not under the max scope allowed ('/go-crawler/docs/'). Adjust the scope, move the Service Worker script, or use the Service-Worker-Allowed HTTP header to allow the scope.