### PR TITLE
Fix typo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
           - 'latest'
           - '0.79.0'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ In addition to this, there are several empty partials you can override to easily
 
 ### Plugins
 
-There are a few features implemented as plugable `scss` styles. Usually these are features that don't make it to the core but can still be useful.
+There are a few features implemented as pluggable `scss` styles. Usually these are features that don't make it to the core but can still be useful.
 
 | Plugin                            | Description                                                 |
 | --------------------------------- | ----------------------------------------------------------- |

--- a/exampleSite/content.en/docs/shortcodes/katex.md
+++ b/exampleSite/content.en/docs/shortcodes/katex.md
@@ -1,3 +1,6 @@
+---
+title: KaTeX
+---
 # KaTeX
 
 KaTeX shortcode let you render math typesetting in markdown document. See [KaTeX](https://katex.org/)

--- a/exampleSite/content.en/menu/index.md
+++ b/exampleSite/content.en/menu/index.md
@@ -16,7 +16,7 @@ headless: true
 - [Columns]({{< relref "/docs/shortcodes/columns" >}})
 - [Expand]({{< relref "/docs/shortcodes/expand" >}})
 - [Hints]({{< relref "/docs/shortcodes/hints" >}})
-- [KaTex]({{< relref "/docs/shortcodes/katex" >}})
+- [KaTeX]({{< relref "/docs/shortcodes/katex" >}})
 - [Mermaid]({{< relref "/docs/shortcodes/mermaid" >}})
 - [Tabs]({{< relref "/docs/shortcodes/tabs" >}})
 <br />

--- a/layouts/shortcodes/katex.html
+++ b/layouts/shortcodes/katex.html
@@ -1,5 +1,5 @@
 {{- if not (.Page.Scratch.Get "katex") -}}
-<!-- Include katext only first time -->
+<!-- Include katex only first time -->
 <link rel="stylesheet" href="{{ "katex/katex.min.css" | relURL }}" />
 <script defer src="{{ "katex/katex.min.js" | relURL }}"></script>
 <script defer src="{{ "katex/auto-render.min.js" | relURL }}" onload="renderMathInElement(document.body);"></script>


### PR DESCRIPTION
This PR fixes a typo I spotted in `README.md`. It also bumps `checkout` action in GitHub `main`workflow to latest version `v4`.