### PR TITLE
Hugo v0.121.1: fix warnings

### DIFF
--- a/exampleSite/content.en/posts/goisforlovers.md
+++ b/exampleSite/content.en/posts/goisforlovers.md
@@ -69,7 +69,7 @@ Accessing the Page Parameter "bar"
 Each Go template has a struct (object) made available to it. In hugo each
 template is passed either a page or a node struct depending on which type of
 page you are rendering. More details are available on the
-[variables](/layout/variables) page.
+[variables](https://gohugo.io/variables/page/) page.
 
 A variable is accessed by referencing the variable name.
 
@@ -83,11 +83,11 @@ Variables can also be defined and referenced.
 
 ## Functions
 
-Go template ship with a few functions which provide basic functionality. The Go
-template system also provides a mechanism for applications to extend the
-available functions with their own. [Hugo template
-functions](/layout/functions) provide some additional functionality we believe
-are useful for building websites. Functions are called by using their name
+Go template ship with a few [functions](https://gohugo.io/functions/go-template/)
+which provide basic functionality. The Go template system also provides
+a mechanism for applications to extend the available functions with their own.
+[Hugo functions](https://gohugo.io/functions/) provide some additional functionality
+we believe are useful for building websites. Functions are called by using their name
 followed by the required parameters separated by spaces. Template
 functions cannot be added without recompiling hugo.
 
@@ -259,7 +259,7 @@ you want to inside of your templates.
 ## Using Content (page) Parameters
 
 In each piece of content you can provide variables to be used by the
-templates. This happens in the [front matter](/content/front-matter).
+templates. This happens in the [front matter](https://gohugo.io/content-management/front-matter/).
 
 An example of this is used in this documentation site. Most of the pages
 benefit from having the table of contents provided. Sometimes the TOC just

--- a/exampleSite/content.en/posts/hugoisforlovers.md
+++ b/exampleSite/content.en/posts/hugoisforlovers.md
@@ -17,7 +17,7 @@ menu = "main"
 
 ## Step 1. Install Hugo
 
-Go to [Hugo releases](https://github.com/spf13/hugo/releases) and download the
+Go to [Hugo releases](https://github.com/gohugoio/hugo/releases) and download the
 appropriate version for your OS and architecture.
 
 Save it somewhere specific as we will be using it in the next step.
@@ -31,14 +31,14 @@ you are reading right now.
 
 Follow the following steps:
 
- 1. Clone the [Hugo repository](http://github.com/spf13/hugo)
+ 1. Clone the [Hugo repository](https://github.com/gohugoio/hugo)
  2. Go into the repo
  3. Run hugo in server mode and build the docs
  4. Open your browser to http://localhost:1313
 
 Corresponding pseudo commands:
 
-    git clone https://github.com/spf13/hugo
+    git clone https://github.com/gohugoio/hugo
     cd hugo
     /path/to/where/you/installed/hugo server --source=./docs
     > 29 pages created
@@ -64,7 +64,7 @@ Now we are going to run hugo again, but this time with hugo in watch mode.
     > Press ctrl+c to stop
 
 
-Open your [favorite editor](http://vim.spf13.com) and change one of the source
+Open your [favorite editor](https://vim.spf13.com) and change one of the source
 content pages. How about changing this very file to *fix the typo*. How about changing this very file to *fix the typo*.
 
 Content files are found in `docs/content/`. Unless otherwise specified, files

--- a/exampleSite/content.en/posts/migrate-from-jekyll.md
+++ b/exampleSite/content.en/posts/migrate-from-jekyll.md
@@ -27,7 +27,7 @@ should become
 Additionally, you'll want any files that should reside at the root (such as `CNAME`) to be moved to `static`.
 
 ## Create your Hugo configuration file
-Hugo can read your configuration as JSON, YAML or TOML. Hugo supports parameters custom configuration too. Refer to the [Hugo configuration documentation](/overview/configuration/) for details.
+Hugo can read your configuration as JSON, YAML or TOML. Hugo supports parameters custom configuration too. Refer to the [Hugo configuration documentation](https://gohugo.io/getting-started/configuration/) for details.
 
 ## Set your configuration publish folder to `_site`
 The default is for Jekyll to publish to `_site` and for Hugo to publish to `public`. If, like me, you have [`_site` mapped to a git submodule on the `gh-pages` branch](http://blog.blindgaenger.net/generate_github_pages_in_a_submodule.html), you'll want to do one of two alternatives:
@@ -47,12 +47,12 @@ The default is for Jekyll to publish to `_site` and for Hugo to publish to `publ
         }
 
 ## Convert Jekyll templates to Hugo templates
-That's the bulk of the work right here. The documentation is your friend. You should refer to [Jekyll's template documentation](http://jekyllrb.com/docs/templates/) if you need to refresh your memory on how you built your blog and [Hugo's template](/layout/templates/) to learn Hugo's way.
+That's the bulk of the work right here. The documentation is your friend. You should refer to [Jekyll's template documentation](https://jekyllrb.com/docs/liquid/) if you need to refresh your memory on how you built your blog and [Hugo's template](https://gohugo.io/categories/templates/) to learn Hugo's way.
 
-As a single reference data point, converting my templates for [heyitsalex.net](http://heyitsalex.net/) took me no more than a few hours.
+As a single reference data point, converting my templates for [heyitsalex.net](https://heyitsalex.net/) took me no more than a few hours.
 
 ## Convert Jekyll plugins to Hugo shortcodes
-Jekyll has [plugins](http://jekyllrb.com/docs/plugins/); Hugo has [shortcodes](/doc/shortcodes/). It's fairly trivial to do a port.
+Jekyll has [plugins](https://jekyllrb.com/docs/plugins/); Hugo has [shortcodes](https://gohugo.io/content-management/shortcodes/). It's fairly trivial to do a port.
 
 ### Implementation
 As an example, I was using a custom [`image_tag`](https://github.com/alexandre-normand/alexandre-normand/blob/74bb12036a71334fdb7dba84e073382fc06908ec/_plugins/image_tag.rb) plugin to generate figures with caption when running Jekyll. As I read about shortcodes, I found Hugo had a nice built-in shortcode that does exactly the same thing.


### PR DESCRIPTION
When building the example site with latest hugo version v0.121.1, several warnings are issued.

```
WARN  Page '/overview/configuration/' not found in 'posts/migrate-from-jekyll.md'
WARN  Page '/layout/templates/' not found in 'posts/migrate-from-jekyll.md'
WARN  Page '/doc/shortcodes/' not found in 'posts/migrate-from-jekyll.md'
WARN  Page '/layout/variables' not found in 'posts/goisforlovers.md'
WARN  Page '/layout/functions' not found in 'posts/goisforlovers.md'
WARN  Page '/content/front-matter' not found in 'posts/goisforlovers.md'
WARN  Expand shortcode is deprecated. Use 'details' instead.
```

This PR fixes all these warnings except for the warning concerning the `expand` shortcode.