### PR TITLE
Change searchData Link to absolute

### DIFF
--- a/assets/search.js
+++ b/assets/search.js
@@ -5,7 +5,7 @@
 {{ $searchConfig := i18n "bookSearchConfig" | default "{}" }}
 
 (function () {
-  const searchDataURL = '{{ $searchData.RelPermalink }}';
+  const searchDataURL = '{{ $searchData.Permalink }}';
   const indexConfig = Object.assign({{ $searchConfig }}, {
     doc: {
       id: 'id',


### PR DESCRIPTION
This pull request is an attempt to address #566.

`$searchData.RelPermalink` does not include the subpath that is present for GitHub pages. Changing it to a `Permalink` seems like a solution that can work.