### PR TITLE
Update link to hugo themes

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -45,7 +45,7 @@ enableGitInfo = true
 
 [[menu.after]]
   name = "Hugo Themes"
-  url = "https://themes.gohugo.io/hugo-book/"
+  url = "https://themes.gohugo.io/themes/hugo-book/"
   weight = 20
 
 [params]

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -41,7 +41,7 @@ menu:
       url: "https://github.com/alex-shpak/hugo-book"
       weight: 10
     - name: "Hugo Themes"
-      url: "https://themes.gohugo.io/hugo-book/"
+      url: "https://themes.gohugo.io/themes/hugo-book/"
       weight: 20
 
 params:


### PR DESCRIPTION
The current link (https://themes.gohugo.io/hugo-book/) redirects to https://themes.gohugo.io/themes/hugo-book/.

I thought I'd update it before the current one is deprecated.