### PR TITLE
replace .Site.IsMultiLingual with hugo.IsMultilingual

### DIFF
--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -1,7 +1,7 @@
 <nav>
 {{ partial "docs/brand" . }}
 {{ partial "docs/search" . }}
-{{ if .Site.IsMultiLingual }}
+{{ if hugo.IsMultilingual }}
   {{ partial "docs/languages" . }}
 {{ end }}
 


### PR DESCRIPTION
# Problem

The warning
```
INFO  deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0
and will be removed in a future release. Use hugo.IsMultilingual
instead.``

shows up

# Solution

Follow the deprecation warning
