### PR TITLE
Use null alt text for calendar.svg and edit.svg

### DIFF
--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -5,7 +5,7 @@
     {{- $date := partial "docs/date" (dict "Date" .GitInfo.AuthorDate.Local "Format" .Site.Params.BookDateFormat) -}}
     {{- $commitPath := default "commit" .Site.Params.BookCommitPath -}}
     <a class="flex align-center" href="{{ .Site.Params.BookRepo }}/{{ $commitPath }}/{{ .GitInfo.Hash }}" title='{{ i18n "Last modified by" }} {{ .GitInfo.AuthorName }} | {{ $date }}' target="_blank" rel="noopener">
-      <img src="{{ "svg/calendar.svg" | relURL }}" class="book-icon" alt="Calendar" />
+      <img src="{{ "svg/calendar.svg" | relURL }}" class="book-icon" alt="" />
       <span>{{ $date }}</span>
     </a>
   </div>
@@ -14,7 +14,7 @@
 {{ if and .File .Site.Params.BookRepo .Site.Params.BookEditPath }}
   <div>
     <a class="flex align-center" href="{{ .Site.Params.BookRepo }}/{{ .Site.Params.BookEditPath }}/{{ .Site.Params.contentDir | default "content" }}/{{ replace .File.Path "\\" "/" }}" target="_blank" rel="noopener">
-      <img src="{{ "svg/edit.svg" | relURL }}" class="book-icon" alt="Edit" />
+      <img src="{{ "svg/edit.svg" | relURL }}" class="book-icon" alt="" />
       <span>{{ i18n "Edit this page" }}</span>
     </a>
   </div>


### PR DESCRIPTION
Closes #592

It seems quite clear to me:

- menu, toc and translate benefit from alt text
- calendar and edit don't