### PR TITLE
Add direction ltr to pre > code and highlight

### DIFF
--- a/assets/_markdown.scss
+++ b/assets/_markdown.scss
@@ -69,6 +69,8 @@
   }
 
   code {
+    direction: ltr;
+    unicode-bidi: embed;
     padding: 0 $padding-4;
     background: var(--gray-200);
     border-radius: $border-radius;
@@ -77,6 +79,7 @@
 
   pre {
     direction: ltr;
+    unicode-bidi: embed;
     padding: $padding-16;
     background: var(--gray-100);
     border-radius: $border-radius;
@@ -153,6 +156,7 @@
   // Special case for highlighted code with line numbers
   .highlight {
     direction: ltr;
+    unicode-bidi: embed;
   }
   
   .highlight table tr {

--- a/assets/_markdown.scss
+++ b/assets/_markdown.scss
@@ -76,6 +76,7 @@
   }
 
   pre {
+    direction: ltr;
     padding: $padding-16;
     background: var(--gray-100);
     border-radius: $border-radius;
@@ -150,6 +151,10 @@
   }
 
   // Special case for highlighted code with line numbers
+  .highlight {
+    direction: ltr;
+  }
+  
   .highlight table tr {
     td:nth-child(1) pre {
       margin: 0;


### PR DESCRIPTION
Thanks for this theme; it's awesome. I'm using it with the Arabic language, and it supports RTL very well. However, code and highlights should always be LTR regardless of the blog site's language. Here is a proposed change that will ensure the code and highlights always appear LTR. Thank you.





