### PR TITLE
Fix for spaces being removed during "minify" build for "mermaid" snippet

### DIFF
--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -7,6 +7,6 @@
 {{ .Page.Scratch.Set "mermaid" true }}
 {{ end }}
 
-<p class="mermaid{{ with .Get "class" }} {{ . }}{{ end }}">
-  {{- .Inner -}}
-</p>
+<pre class="mermaid{{ with .Get "class" }} {{ . }}{{ end }}">
+  {{- .Inner | safeHTML -}}
+</pre>


### PR DESCRIPTION
"mindmap" style is not rendered correctly with "--minify"  because spaces are removed from final HTML