### PR TITLE
use .Sites.Default instead of .Sites.First

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         hugo-version:
           - 'latest'
-          - '0.124.0'
+          - '0.128.0'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/layouts/partials/docs/brand.html
+++ b/layouts/partials/docs/brand.html
@@ -1,5 +1,5 @@
 <h2 class="book-brand">
-  <a class="flex align-center" href="{{ cond (not .Site.Home.File) .Sites.First.Home.RelPermalink .Site.Home.RelPermalink }}">
+  <a class="flex align-center" href="{{ cond (not .Site.Home.File) .Sites.Default.Home.RelPermalink .Site.Home.RelPermalink }}">
     {{- with .Site.Params.BookLogo -}}
     <img src="{{ . | relURL }}" alt="Logo" />
     {{- end -}}


### PR DESCRIPTION
# Problem

The warning
```
INFO  deprecated: .Sites.First was deprecated in Hugo v0.127.0 and will be removed in a future release. Use .Sites.Default instead.
```

appears

# Solution

Follow the warning. Use `.Sites.Default`
