### PR TITLE
Auto-generate ID for tabs

### DIFF
--- a/exampleSite/content.en/docs/shortcodes/tabs.md
+++ b/exampleSite/content.en/docs/shortcodes/tabs.md
@@ -3,7 +3,7 @@
 Tabs let you organize content by context, for example installation instructions for each supported platform.
 
 ```tpl
-{{</* tabs "uniqueid" */>}}
+{{</* tabs */>}}
 {{</* tab "MacOS" */>}} # MacOS Content {{</* /tab */>}}
 {{</* tab "Linux" */>}} # Linux Content {{</* /tab */>}}
 {{</* tab "Windows" */>}} # Windows Content {{</* /tab */>}}
@@ -12,7 +12,7 @@ Tabs let you organize content by context, for example installation instructions 
 
 ## Example
 
-{{< tabs "uniqueid" >}}
+{{< tabs >}}
 {{< tab "MacOS" >}}
 # MacOS
 

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,6 +1,6 @@
 {{ if .Parent }}
   {{ $name := .Get 0 }}
-  {{ $group := printf "tabs-%s" (.Parent.Get 0) }}
+  {{ $group := printf "tabs-%d" .Parent.Ordinal }}
 
   {{ if not (.Parent.Scratch.Get $group) }}
     {{ .Parent.Scratch.Set $group slice }}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,6 +1,5 @@
 {{ if .Inner }}{{ end }}
-{{ $id := .Get 0 }}
-{{ $group := printf "tabs-%s" $id }}
+{{ $group := printf "tabs-%d" .Ordinal }}
 
 <div class="book-tabs">
 {{- range $index, $tab := .Scratch.Get $group -}}


### PR DESCRIPTION
Use [.Ordinal](https://gohugo.io/methods/shortcode/ordinal/) instead of user-provided string argument to generate a unique ID for `tabs`. It makes the tabs easier to use, no need to come up with a unique name for each tabs group anymore.

The change is backward-compatible: user-provided ID will be simply ignored.