### PR TITLE
fix: hreflang for link rel=alternate uses site language code

### DIFF
--- a/layouts/partials/docs/html-head.html
+++ b/layouts/partials/docs/html-head.html
@@ -19,7 +19,7 @@
 <link rel="canonical" href="{{ .Permalink }}">
 
 {{- range .Translations }}
-  <link rel="alternate" hreflang="{{ default .Language.Lang .Site.LanguageCode }}" href="{{ .Permalink }}" title="{{ partial "docs/title" . }}">
+  <link rel="alternate" hreflang="{{ default .Site.LanguageCode .Language.Lang }}" href="{{ .Permalink }}" title="{{ partial "docs/title" . }}">
 {{- end -}}
 
 <!-- Theme stylesheet, you can customize scss by creating `assets/custom.scss` in your website -->


### PR DESCRIPTION
The hugo default function returns second argument if set and first if second is not set.

Before this PR, second parameter is site.languagecode which is current language code, not language of translation.
After this PR, correctly use language code of translation
