### PR TITLE
Three hugo deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ public/
 exampleSite/public/
 .DS_Store
 .hugo_build.lock
+resources/

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ headless = true
 
 And Enable it by setting `BookMenuBundle: /menu` in Site configuration.
 
-- [Example menu](https://github.com/alex-shpak/hugo-book/blob/master/exampleSite/content/menu/index.md)
+- [Example menu](https://github.com/alex-shpak/hugo-book/blob/master/exampleSite/content.en/menu/index.md)
 - [Example config file](https://github.com/alex-shpak/hugo-book/blob/master/exampleSite/config.yaml)
 - [Leaf bundles](https://gohugo.io/content-management/page-bundles/)
 

--- a/layouts/partials/docs/brand.html
+++ b/layouts/partials/docs/brand.html
@@ -1,5 +1,5 @@
 <h2 class="book-brand">
-  <a class="flex align-center" href="{{ cond (not .Site.Home.File) .Sites.First.Home.RelPermalink .Site.Home.RelPermalink }}">
+  <a class="flex align-center" href="{{ cond (not .Site.Home.File) .Sites.Default.Home.RelPermalink .Site.Home.RelPermalink }}">
     {{- with .Site.Params.BookLogo -}}
     <img src="{{ . | relURL }}" alt="Logo" />
     {{- end -}}

--- a/layouts/partials/docs/html-head.html
+++ b/layouts/partials/docs/html-head.html
@@ -21,9 +21,8 @@
 {{- end -}}
 
 <!-- Theme stylesheet, you can customize scss by creating `assets/custom.scss` in your website -->
-{{- $styles := resources.Get "book.scss" | resources.ExecuteAsTemplate "book.scss" . | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+{{- $styles := resources.Get "book.scss" | resources.ExecuteAsTemplate "book.scss" . | css.Sass | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $styles.RelPermalink }}" {{ template "integrity" $styles }}>
-
 {{- if default true .Site.Params.BookSearch -}}
   {{- $searchJSFile := printf "%s.search.js" .Language.Lang }}
   {{- $searchJS := resources.Get "search.js" | resources.ExecuteAsTemplate $searchJSFile . | resources.Minify | resources.Fingerprint }}

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -1,7 +1,7 @@
 <nav>
 {{ partial "docs/brand" . }}
 {{ partial "docs/search" . }}
-{{ if .Site.IsMultiLingual }}
+{{ if hugo.IsMultiLingual }}
   {{ partial "docs/languages" . }}
 {{ end }}
 

--- a/layouts/partials/docs/menu.html
+++ b/layouts/partials/docs/menu.html
@@ -1,7 +1,7 @@
 <nav>
 {{ partial "docs/brand" . }}
 {{ partial "docs/search" . }}
-{{ if hugo.IsMultiLingual }}
+{{ if hugo.IsMultilingual }}
   {{ partial "docs/languages" . }}
 {{ end }}
 


### PR DESCRIPTION
  - resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.Sass instead.
  - deprecated: .Sites.First was deprecated in Hugo v0.127.0 and will be removed in a future release.
  - ERROR deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.137.0.