### PR TITLE
Make book header always visible

### DIFF
--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -298,9 +298,16 @@ body[dir="rtl"] .book-menu {
 }
 
 @media screen and (max-width: $mobile-breakpoint) {
+  h1, h2, h3, h4, h5, h6 {
+    scroll-margin-top: 3rem;
+  }
+
   #menu-control,
   #toc-control {
     display: inline;
+    // prevents scrolling to top when inputs focused
+    position: fixed;
+    top: 0;
   }
 
   .book-menu {
@@ -314,7 +321,16 @@ body[dir="rtl"] .book-menu {
   }
 
   .book-header {
+    background: var(--body-background);
+    border-bottom: 2px solid var(--color-visited-link);
     display: block;
+    max-height: 100vh;
+    overflow: auto;
+    padding: .35rem 0;
+    position: sticky;
+    top: -1px;
+    // prevent background from being transparent
+    z-index: 1;
   }
 
   #menu-control:focus ~ main label[for="menu-control"] {

--- a/assets/book-header.js
+++ b/assets/book-header.js
@@ -1,0 +1,18 @@
+(function () {
+  let tocLinks = document.querySelectorAll("#TableOfContents li");
+  let tocInput = document.getElementById("toc-control");
+  tocLinks.forEach(l =>
+    l.addEventListener("click",
+      () => tocInput.checked = false));
+})();
+(function () {
+  let menuLabel = document.querySelector("label[for='menu-control']");
+  let menuInput = document.getElementById("menu-control");
+  let tocInput = document.getElementById("toc-control");
+  menuLabel.addEventListener("click",
+    function () {
+      if (!menuInput.checked) {
+        tocInput.checked = false;
+      }
+    });
+})();

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,6 +21,13 @@
 
       {{ partial "docs/inject/content-before" . }}
       {{ template "main" . }} <!-- Page Content -->
+
+      <!-- Improve .book-header usability on mobile devices -->
+      {{ $script := resources.Get "book-header.js" | resources.Minify }}
+      {{ with $script.Content }}
+        <script>{{ . | safeJS }}</script>
+      {{ end }}
+
       {{ partial "docs/inject/content-after" . }}
 
       <footer class="book-footer">


### PR DESCRIPTION
I am using this theme for a book with long chapters. Scrolling to the top of the page on mobile devices to access the table of contents and site navigation is not user friendly. This PR makes the .book-header `sticky` so that the site navigation and table of contents can be accessed from any place on the page. :partying_face: 

*The header is accessible from partways down the page.*
![image](https://github.com/user-attachments/assets/df761b8b-cc56-4638-9403-b7bffc21850b)

Notes:
- The basic functionality does not require Javascript to work.
- However, Javascript adds the following UX improvements:
    - *The Table of Contents is closed when selecting the site navigation.* On small devices with a large table of contents, there was no place to tap to close the site navigation menu. By closing the TOC when opening site navigation, we make sure there is a place to tap to close the site navigation.
    - *The Table of Contents is closed when tapping a heading.* This is done so that the we could set `scroll-margin-top` to a value that would guarantee the heading was visible at the top of the viewport.

![image](https://github.com/user-attachments/assets/77195fdd-6aa4-454b-8987-f7235607d9b4)
