### PR TITLE
Add Parameters for a page content license

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ disableKinds = ['taxonomy', 'taxonomyTerm']
   # /!\ This is an experimental feature, might be removed or changed at any time
   # (Optional, experimental, default false) Enables service worker that caches visited pages and resources for offline use.
   BookServiceWorker = true
+
+  # (Optional) Specifies a License that applies to the content of the page
+  # BookContentLicenseText = 'CC-BY-SA-4.0'
+
+  # (Optional) Specifies a Link for the License that applies to the content of the page
+  # Requires 'BookContentLicenseText' param.
+  # BookContentLicenseLink = 'https://creativecommons.org/licenses/by-sa/4.0/'
 ```
 
 ### Multi-Language Support

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -117,3 +117,10 @@ enableGitInfo = true
   # /!\ This is an experimental feature, might be removed or changed at any time
   # (Optional, experimental, default false) Enables a drop-down menu for translations only if a translation is present.
   BookTranslatedOnly = false
+
+  # (Optional) Specifies a License that applies to the content of the page
+  # BookContentLicenseText = 'CC-BY-SA-4.0'
+
+  # (Optional) Specifies a Link for the License that applies to the content of the page
+  # Requires 'BookContentLicenseText' param.
+  # BookContentLicenseLink = 'https://creativecommons.org/licenses/by-sa/4.0/'

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -113,3 +113,10 @@ params:
   # /!\ This is an experimental feature, might be removed or changed at any time
   # (Optional, experimental, default false) Enables a drop-down menu for translations only if a translation is present.
   BookTranslatedOnly: false
+
+  # (Optional) Specifies a License that applies to the content of the page
+  # BookContentLicenseText: CC-BY-SA-4.0
+
+  # (Optional) Specifies a Link for the License that applies to the content of the page
+  # Requires 'BookContentLicenseText' param.
+  # BookContentLicenseLink: https://creativecommons.org/licenses/by-sa/4.0/

--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -19,6 +19,19 @@
   </div>
 {{ end }}
 
+{{ if and .File .Site.Params.BookContentLicenseText }}
+  <div class="flex align-center">
+      <span class="book-icon" alt="" />📖&nbsp;</span>
+      {{ if and .File .Site.Params.BookContentLicenseLink }}
+      <a href="{{ .Site.Params.BookContentLicenseLink }}" title='License' target="_blank" rel="noopener">
+        <span>{{ .Site.Params.BookContentLicenseText }}</span>
+      </a>
+      {{ else }}
+      <span>{{ .Site.Params.BookContentLicenseText }}</span>
+      {{ end }}
+  </div>
+{{ end }}
+
 </div>
 
 {{ $script := resources.Get "clipboard.js" | resources.Minify }}


### PR DESCRIPTION
This allows people to specify which License conditions apply for the
content they're hosting.
