### PR TITLE
Docs: Change tabs shortcode example to permit unsafe=false

### DIFF
--- a/exampleSite/content.en/docs/shortcodes/tabs.md
+++ b/exampleSite/content.en/docs/shortcodes/tabs.md
@@ -3,16 +3,16 @@
 Tabs let you organize content by context, for example installation instructions for each supported platform.
 
 ```tpl
-{{%/* tabs "id" */%}}
+{{</* tabs "id" */>}}
 {{%/* tab "MacOS" */%}} # MacOS Content {{%/* /tab */%}}
 {{%/* tab "Linux" */%}} # Linux Content {{%/* /tab */%}}
 {{%/* tab "Windows" */%}} # Windows Content {{%/* /tab */%}}
-{{%/* /tabs */%}}
+{{</* /tabs */>}}
 ```
 
 ## Example
 
-{{% tabs %}}
+{{< tabs >}}
 
 {{% tab "MacOS" %}}
 # MacOS
@@ -47,4 +47,4 @@ protulit, sed sed aere valvis inhaesuro Pallas animam: qui _quid_, ignes.
 Miseratus fonte Ditis conubia.
 {{% /tab %}}
 
-{{% /tabs %}}
+{{< /tabs >}}


### PR DESCRIPTION
The syntax of `{{% code %}}` only expects Markdown inside. That's why it triggers unsafe warning, if used as a shortcode template.

Instead the only the top table shortcode should be used as `{{< tabs >}}` to include the HTML, while the user may use only `{{% tab "Name" %}}` inside and be happily restricted to Markdown.

https://gohugo.io/methods/page/rendershortcodes/#shortcode-notation
https://github.com/InfosecForActivistsTeam/infosec-activists/pull/45

---

I have not added any notes to README.md. Yes, I have tested with unsafe=false and the tabs worked while other pages generated warnings.