### PR TITLE
fix: change article title from h2 to h1 in single.html

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
 <article class="markdown book-post">
-  <h2>
+  <h1>
     {{ partial "docs/title.html" . }}
-  </h2>
+  </h1>
   {{ partial "docs/post-meta" . }}
   <div class="book-post-content">
     {{- .Content -}}


### PR DESCRIPTION
fix: change article title from h2 to h1 in single.html

Corrected the semantic structure of article pages by using h1 for the main title
instead of h2. This ensures proper HTML semantics with only one h1 per page,
improving both accessibility and SEO performance.