### PR TITLE
Improve nav a11y

### DIFF
--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -48,12 +48,13 @@ aside nav ul {
   list-style: none;
 
   li {
-    margin: 1em 0;
+    margin: 0;
     position: relative;
   }
 
   a {
     display: block;
+    line-height: 2;
   }
 
   a:hover {
@@ -262,10 +263,6 @@ body[dir="rtl"] .book-menu {
   img {
     height: 1em;
     width: 1em;
-  }
-
-  nav > ul > li:first-child {
-    margin-top: 0;
   }
 }
 


### PR DESCRIPTION
WCAG 2.2 AA guidelines say buttons should have at least a 24x24 clickable area. The theme currently has 16px clickable height due to low line-height. We can replace the margins with an increased line height to get mostly the same visual appearance but a much higher 28px clickable height, making sites more accessible