### PR TITLE
Add scrollbar-gutter: stable

### DIFF
--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -2,6 +2,7 @@ html {
   font-size: $font-size-base;
   scroll-behavior: smooth;
   touch-action: manipulation;
+  scrollbar-gutter: stable;
 }
 
 body {


### PR DESCRIPTION
Add `scrollbar-gutter: stable` to the root html element.

Per [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter):

> The scrollbar-gutter [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) property allows authors to reserve space for the scrollbar, preventing unwanted layout changes as the content grows while also avoiding unnecessary visuals when scrolling isn't needed.

This means that when navigating between pages long enough to show a scrollbar and pages short enough to be displayed without one, content like sidebars, centered elements, etc all stay in exactly the same place.