### PR TITLE
fix: links to fragment on same page should not be made portable

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -7,7 +7,8 @@
 {{- define "portable-link" -}}
   {{- $destination := .Destination }}
   {{- $isRemote := or (in .Destination ":") (strings.HasPrefix .Destination "//") }}
-  {{- if not $isRemote }}
+  {{- $isFragment := strings.HasPrefix .Destination "#" }}
+  {{- if and (not $isRemote) (not $isFragment) }}
     {{- $url := urls.Parse .Destination }}
     {{- $path := strings.TrimSuffix "/_index.md" $url.Path }}
     {{- $path = strings.TrimSuffix "/_index" $path }}


### PR DESCRIPTION
Linking to a heading on the same page should not be affected by the `BookPortableLinks` setting.

`.Page.GetPage` would return the homepage for a empty path, breaking links to headings on any other page than the homepage. This PR fixes that by skipping URLs that only contain a fragment.