### PR TITLE
Add rel=edit link to editing link

### DIFF
--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -12,7 +12,7 @@
 
 {{ if and .File .Site.Params.BookRepo .Site.Params.BookEditPath }}
   <div>
-    <a class="flex align-center" href="{{ partial "docs/links/edit" . }}" target="_blank" rel="noopener">
+    <a class="flex align-center" href="{{ partial "docs/links/edit" . }}" target="_blank" rel="noopener edit">
       <img src="{{ "svg/edit.svg" | relURL }}" class="book-icon" alt="" />
       <span>{{ i18n "Edit this page" }}</span>
     </a>


### PR DESCRIPTION
This PR adds the rel="edit" attribute to the "Edit this page" link in the footer of the theme.

rel=edit lets a page indicate that the linked resource can be used to edit the page. It is defined at https://microformats.org/wiki/rel-edit. This can then be parsed by tools like the Universal Edit Button and custom bookmarklets to open the edit page corresponding with a website.