### PR TITLE
Added support for ```mermaid

### DIFF
--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,4 @@
+<pre class="mermaid">
+  {{ .Inner | htmlEscape | safeHTML }}
+</pre>
+{{ .Page.Store.Set "hasMermaid" true }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -81,3 +81,9 @@
 {{ define "toc" }}
   {{ partial "docs/toc" . }}
 {{ end }}
+{{ if .Store.Get "hasMermaid" }}
+  <script type="module">
+    import mermaid from 'mermaid.min.js';
+    mermaid.initialize({ startOnLoad: true });
+  </script>
+{{ end }}


### PR DESCRIPTION
Most editors I've used support ```mermaid  instead of using "shortcodes"
I used [hugo's docs](https://gohugo.io/content-management/diagrams/) and added it to the layouts to support this notation for mermaid.

This may be a "breaking change" for users who assume that ```mermaid doesn't render graphs...