### PR TITLE
Remove unneeded portable link trim

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -10,10 +10,7 @@
   {{- $isFragment := strings.HasPrefix .Destination "#" }}
   {{- if and (not $isRemote) (not $isFragment) }}
     {{- $url := urls.Parse .Destination }}
-    {{- $path := strings.TrimSuffix "/_index.md" $url.Path }}
-    {{- $path = strings.TrimSuffix "/_index" $path }}
-    {{- $path = strings.TrimSuffix ".md" $path }}
-    {{- $page := .Page.GetPage $path }}
+    {{- $page := .Page.GetPage $url.Path }}
     {{- if $page }}
       {{- $destination = $page.RelPermalink }}
       {{- if $url.Fragment }}


### PR DESCRIPTION
I'm not sure why the trimming is done, since it makes `.Page.GetPage` unable to find some files.

The relevant Hugo code even says ["We are always looking for a content file and having an extension greatly simplifies the code"](https://github.com/gohugoio/hugo/blob/bbcc2a797361956ce249d864bffbe2295947870b/hugolib/pagecollections.go#L129-L130).

Removing the trim makes portable links work more often.