### PR TITLE
toc-show.html: enforce default value true for .Site.Params.BookToc

### DIFF
--- a/layouts/_partials/docs/toc-show.html
+++ b/layouts/_partials/docs/toc-show.html
@@ -1,5 +1,4 @@
-{{ return default true (
-  and
-    (default .Site.Params.BookToC .Params.BookToC)
+{{ return and
+    (default .Site.Params.BookToC .Params.BookToC | default true)
     (not (eq .TableOfContents "<nav id=\"TableOfContents\"></nav>"))
-) }}
+}}


### PR DESCRIPTION
When `.Site.Params.BookToC` is not set, it defaults to `true`.  Before this change the whole expression in toc-show.html always returned `false`, when `.Site.Params.BookToC` was not set.

Related to https://github.com/alex-shpak/hugo-book/issues/750#issuecomment-3157464974.