### PR TITLE
Refactor condition for Table of Contents display (bookToC)

### DIFF
--- a/layouts/_partials/docs/toc-show.html
+++ b/layouts/_partials/docs/toc-show.html
@@ -1,5 +1,5 @@
-{{- return or
-  (and (eq .Type "posts") (eq .Kind "section"))
+{{- return and
+  (not (eq .Params.bookToC false))
+  (not (eq .Site.Params.BookToC false))
   (not (eq .TableOfContents "<nav id=\"TableOfContents\"></nav>"))
-  (default .Site.Params.BookToC .Params.BookToC)
 -}}


### PR DESCRIPTION
Fix `bookToC` not responding to `true` or `false` globally (Hugo config) or locally (front matter) by simplifying the logic and making TOC behaviour consistent across **all page types**.

Changes made:

- Modify layouts/partials/docs/toc-show.html to use an `and` condition instead of `or`:
- Remove the `(and (eq .Type "posts") (eq .Kind "section"))` condition, as it unconditionally enabled the TOC for "posts" section pages, overriding user settings.

The new logic ensures the TOC is only rendered if:

- BookToC is not explicitly set to false (globally or per-page), *and*
- Page has a non-empty TOC (i.e., **does contain** headings).

Usage:

- Users can disable the TOC by setting `BookToC: false` in `hugo.toml` (global) or `bookToC: false` in front matter (per-page), regardless of page type or content.
- Maintains compatibility with existing behaviour for pages with `BookToC: true` or unset, only rendering the TOC when headings are present.
- Removes the requirement for "posts" sections, simplifying the logic, making TOC settings consistent across all page types.