### PR TITLE
remove a a duplicated word in example site

### DIFF
--- a/exampleSite/content.en/posts/creating-a-new-theme.md
+++ b/exampleSite/content.en/posts/creating-a-new-theme.md
@@ -290,7 +290,7 @@ tags = ["tags", "categories"]
 ## the bit that says "YOUR_NAME_HERE"
 ```
 
-Note that the the skeleton's template files are empty. Don't worry, we'll be changing that shortly.
+Note that the skeleton's template files are empty. Don't worry, we'll be changing that shortly.
 
 ```
 $ find themes/zafta -name '*.html' | xargs ls -l


### PR DESCRIPTION
I found this when looking for duplicative words in my own use.