### PR TITLE
Improve nav links

### DIFF
--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -61,6 +61,14 @@ aside nav ul {
     opacity: 0.5;
   }
 
+  a:not([href]) {
+    color: var(--gray-500);
+  }
+
+  a.active {
+    font-weight: bold;
+  }
+
   ul {
     padding-inline-start: $padding-16;
   }


### PR DESCRIPTION
- Make nav links look unclickable if they cannot be clicked (which happens if they have no content)
- Show the current page in the nav by making the link bold

I found myself copying these rules into new sites' `_custom.scss`, so I wondered if they might be useful to others as well. In this screenshot, the "Guides" heading is not clickable because `docs/guides/_index.md` has only frontmatter with no content, and I'm currently on the "Per-Page Header Example" page.

<img width="262" height="343" alt="Screenshot 2026-02-12 at 06 18 42" src="https://github.com/user-attachments/assets/02d4203f-8e5b-4959-b6f0-b314bb87d489" />