### PR TITLE
Allow overriding the site global copyright with page local params

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ enableGitInfo = true
 # You can remove related files with config below
 disableKinds = ['taxonomy', 'taxonomyTerm']
 
+# (Optional) Copyright information of the hugo book content
+copyright = '[© CC BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)'
+
 [params]
   # (Optional, default light) Sets color theme: light, dark or auto.
   # Theme 'auto' switches between dark and light modes based on browser/os preferences. With plugins/themes added there are more themes.
@@ -201,6 +204,10 @@ type = 'docs'
 
 # Set page weight to re-arrange items in file-tree menu.
 weight = 10
+
+# (Optional) Copyright information of the hugo page content
+# Can be used to override the site-wide copyright notice
+copyright = '[© CC BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)'
 
 # (Optional) Set to 'true' to mark page as flat section in file-tree menu.
 bookFlatSection = false

--- a/layouts/_partials/docs/copyright.html
+++ b/layouts/_partials/docs/copyright.html
@@ -1,1 +1,1 @@
-<small>{{ .Site.Title }} - {{ .Site.Copyright | .RenderString }}</small>
+<small>{{ .Site.Title }} - {{ default .Site.Copyright .Params.Copyright | .RenderString }}</small>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -71,7 +71,7 @@
 {{ end }}
 
 {{ define "copyright" }}
-  {{ if .Site.Copyright }}
+  {{ if or .Site.Copyright .Params.Copyright }}
   <div class="book-copyright flex justify-center">
     {{ partial "docs/copyright" . }}
   </div>


### PR DESCRIPTION
This is useful when certain sub pages may have a different copyright than the entire rest of the site.