### PR TITLE
Fix tabs: use page-level counter for unique group IDs

### DIFF
--- a/layouts/_shortcodes/tab.html
+++ b/layouts/_shortcodes/tab.html
@@ -1,4 +1,7 @@
-{{- $group := printf "tabs-%v" (.Parent.Store.Get "id") -}}
+{{- if not .Ordinal -}}{{- /* first tab sets group ID */ -}}
+  {{- .Parent.Store.Set "id" (partial "docs/text/shortcode-id" .Parent) -}}
+{{- end -}}
+{{- $group := printf "tabs-%d" (.Parent.Store.Get "id") -}}
 {{- $tab := printf "%s-%d" $group .Ordinal -}}
 <input type="radio" class="toggle" name="{{ $group }}" id="{{ $tab }}" {{ if not .Ordinal }}checked="checked"{{ end }} />
 {{- /* remove whitespaces */ -}}

--- a/layouts/_shortcodes/tabs.html
+++ b/layouts/_shortcodes/tabs.html
@@ -1,4 +1,3 @@
-{{- .Store.Set "id" (partial "docs/text/shortcode-id" .) -}}
 {{- $attributes := partial "docs/text/mapper" (dict
   "attributes" (cond .IsNamedParams .Params dict)
   "merge" (dict


### PR DESCRIPTION
.Page.Store.Add is broken in Hugo 0.158+ (returns nil).
Additionally, Hugo renders shortcodes bottom-up, so the parent
tabs.html cannot pass data to child tab.html via .Store.

Fix:
- shortcode-id partial: replace .Page.Store.Add with explicit
  .Page.Store.Set + add, which works in Hugo 0.161+.
- tab.html: the first child tab generates a page-unique ID via
  the partial and caches it on .Parent.Store for siblings.
- tabs.html: remove broken .Store.Set "id" line.

This avoids the .Parent.Ordinal collision when tabs are nested
inside other shortcodes (details, columns, etc.).

Closes https://github.com/alex-shpak/hugo-book/issues/817