### PR TITLE
fix: dark theme compatibility with dark-reader extension

### DIFF
--- a/layouts/_partials/docs/html-head.html
+++ b/layouts/_partials/docs/html-head.html
@@ -9,6 +9,9 @@ https://github.com/alex-shpak/hugo-book
 <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">
 <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#2e3440">
 <meta name="color-scheme" content="light dark">
+{{- if eq .Site.Params.BookTheme "dark" }}
+<meta name="darkreader-lock">
+{{- end }}
 
 {{- with .Page.Params.BookHref -}}
   <meta http-equiv="Refresh" content="0; url='{{ . }}'" />


### PR DESCRIPTION
I use [dark reader](https://github.com/darkreader/darkreader) extension and the dark theme here was getting mangled by it.

This PR emits a [meta tag](https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-statically) to signal extension that site has native dark mode.

Before:
<img width="1074" height="699" alt="image" src="https://github.com/user-attachments/assets/cea15574-f349-4d00-8c82-52970c7ef08a" />

After:
<img width="1079" height="749" alt="image" src="https://github.com/user-attachments/assets/938e500e-bb2d-4609-bc4d-97fffc8f3a68" />
