### PR TITLE
Font Awesome icon support for section Icons

### DIFF
--- a/layouts/_partials/docs/html-head.html
+++ b/layouts/_partials/docs/html-head.html
@@ -31,6 +31,11 @@ https://github.com/alex-shpak/hugo-book
 <!-- Theme stylesheet, you can customize it by creating `assets/styles/custom.css` in your website -->
 {{ partial "docs/html-head-styles" . }}
 
+<!-- Font Awesome -->
+{{- if .Site.Params.FontAwesome -}}
+<link  rel="stylesheet"  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
+{{ end -}}
+
 <!-- Search -->
 {{- if default true .Site.Params.BookSearch -}}
   {{- $searchJSFile := printf "%s.search.js" .Language.Name }}

--- a/layouts/_partials/docs/menu-filetree.html
+++ b/layouts/_partials/docs/menu-filetree.html
@@ -49,6 +49,10 @@
 {{ define "book-icon-title" }}
 {{- with .Page.Params.BookIcon -}}
   <img src="{{ partial "docs/icon" . }}" class="book-icon" alt="{{ partial "docs/text/i18n" . }}" />
+{{- else -}}
+  {{- with .Page.Params.fontAwesomeIcon -}}
+    <i class="book-icon {{ . }}" aria-hidden="true"></i>
+  {{- end -}}
 {{- end -}}
 {{- partial "docs/title" .Page -}}
 {{ end }}


### PR DESCRIPTION
## FontAwesome Icons for Section Icons

I really enjoy using this theme and am very happy with it. For my personal use, I implemented a small feature that allows FontAwesome icons to be used as section icons, similar to the existing `BookIcons` feature.

This approach means that FontAwesome SVG files no longer need to be downloaded and added to the repository individually. Icons can simply be referenced by their CSS class name.

### How it works

The icons are rendered using an `<i>` element with the corresponding FontAwesome CSS classes. The element is marked with `aria-hidden="true"` so that screen readers will ignore the decorative icon.

To enable the feature, `FontAwesome` needs to be set to `true` in `hugo.toml`:

```toml
[params]
    FontAwesome = true
```

After enabling the feature, a section icon can be specified in the sections frontmatter, for example:

```toml
fontAwesomeIcon = "fa-solid fa-file-code"
```

The corresponding FontAwesome icon will then be displayed as the section icon.

### Features

* Extends the existing `BookIcons` functionality to support FontAwesome icons for sections.
* Uses only HTML and CSS, no JavaScript is required.
* Reuses the existing `book-icon` CSS class for consistent styling and integration.
* Compatible with dark mode; icons automatically adapt to the current theme.
* Opt-in by design: the feature must be explicitly enabled via `hugo.toml`, so the default configuration and existing behavior remain unchanged.
* FontAwesome is available under a permissive license, making it suitable for users of the theme, even in commercial contexts: https://fontawesome.com/license/free

This provides a simple way to use the large FontAwesome icon library without having to manage individual SVG files.

I have included an example image below.

<img width="1214" height="971" alt="fontawesomeicons" src="https://github.com/user-attachments/assets/a7ae6499-cb52-407d-9480-d4ad09ff9294" />
